### PR TITLE
[#20] Support weapons with different ranges at different OB levels

### DIFF
--- a/.claude/skills/add-effect/SKILL.md
+++ b/.claude/skills/add-effect/SKILL.md
@@ -137,37 +137,42 @@ Pick a real example and fill in the actual values.
 
 ## Step 5 — Update `src/Core/Database.purs`
 
-### 5a. `areWeaponEffectsEquivalent` (inside `getDistinctObs`)
+The grouping logic is driven by three small top-level helper functions, each an exhaustive `case _ of` over **every** `WeaponEffect` constructor. Add a branch to each one. (Because they're exhaustive, a missing branch surfaces as a non-exhaustiveness warning at build time — see Step 8.)
 
-Add a case. Two effects of the same type are "equivalent" (same OB slot) if their potencies AND range match — duration/extension are ignored.
+### 5a. `rangeOf`
 
-```purescript
--- for withDurExt or withDurExtPercentage (no potencies):
-FireResistUp { range: range1, durExt: _ } ->
-  case y of
-    FireResistUp { range: range2, durExt: _ } -> range1 == range2
-    _ -> crash unit
-
--- for withDurExtPotencies (has potencies):
-FireResistUp { range: range1, durExt: _, potencies: pot1 } ->
-  case y of
-    FireResistUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-    _ -> crash unit
-```
-
-### 5b. `groupForWeaponEffect`
-
-Add a case that determines how the effect is grouped in the database:
+Every constructor carries a `range` field, so the branch is always the same:
 
 ```purescript
--- for effects WITHOUT potencies:
-FireResistUp { range } -> Just { effectType: FilterFireResistUp, range: Just range, potencies: Nothing }
-
--- for effects WITH potencies — must extract potencies from all 4 OB levels:
-FireResistUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-  FireResistUp ob1, FireResistUp ob6, FireResistUp ob10 -> Just { effectType: FilterFireResistUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-  _, _, _ -> crash unit
+FireResistUp r -> r.range
 ```
+
+### 5b. `potenciesOf`
+
+```purescript
+-- for effects WITH potencies (withDurExtPotencies):
+FireResistUp r -> Just r.potencies
+
+-- for effects WITHOUT potencies (withDurExt / withDurExtPercentage / withPercentage):
+FireResistUp _ -> Nothing
+```
+
+### 5c. `tagOf`
+
+Maps the constructor to its `FilterEffectType`. This is what makes the effect show up in the database (it's used by `groupForWeaponEffect` to pick the `effectType`):
+
+```purescript
+FireResistUp _ -> FilterFireResistUp
+```
+
+### 5d. `groupForWeaponEffect` and `areWeaponEffectsEquivalent` — usually NO change
+
+Both now derive everything from the helpers above:
+
+- `groupForWeaponEffect` builds `allRanges` via `rangeOf`, `allPotencies` via `potenciesOf`, and the `effectType` via `tagOf` (its `effectTypeOf` has a catch-all `_ -> Just (tagOf ob0)`).
+- `areWeaponEffectsEquivalent` is just `tagOf x /= tagOf y` (crash on mismatch) otherwise `rangeOf x == rangeOf y && potenciesOf x == potenciesOf y`.
+
+So a normal effect needs no edits here. **Only** add an explicit case if the effect needs special inclusion logic — e.g. `Heal` is only grouped when its percentage ≥ 30, so it has its own branch in `effectTypeOf`. If your effect should always be included whenever present, do nothing in this step beyond 5a–5c.
 
 ## Step 6 — Update `src/App/EffectSelector.purs`
 
@@ -218,6 +223,6 @@ just check-effects
 Open `resources/unsupported_effects.md` and confirm the effect no longer appears in the list. If the effect still appears, check:
 
 1. Does the parser string exactly match the raw game text?
-2. Is the effect in `groupForWeaponEffect` — that's what puts it in the DB
+2. Is the effect in `tagOf` — that's what gives it a `FilterEffectType` and puts it in the DB (alongside `rangeOf` / `potenciesOf`)
 
-If the tests fail with exhaustiveness errors, you missed one of the parallel pattern-match blocks in `Types.purs`.
+If the tests fail with exhaustiveness warnings/errors, you missed one of the parallel pattern-match blocks. These live in `Types.purs` (the `Show`/`WriteForeign`/`ReadForeign` instances and the two `exhaustive*` arrays) and in `Database.purs` (the `rangeOf` / `potenciesOf` / `tagOf` helpers).

--- a/justfile
+++ b/justfile
@@ -6,6 +6,7 @@ build:
     spago build
 
 build-prod:
+    xreferee
     # The Google Sheets API key comes from `.env` (prod key); the private dev key lives only in the
     # gitignored `.env.development.local`, which `parcel build` (production mode) never loads.
     #

--- a/notes.md
+++ b/notes.md
@@ -10,9 +10,9 @@
 
 ## Decisions
 
-* We do not consider Ultimate Weapons; they're usually not a reliably way of keeping buffs/debuffs applied throughout a battle.
-* We consider "Healing Weapons" as weapons that have either a `All (Cure Spells)` S. Ability or a C. Ability that heals for at least 30%.
-    * This last criterium is used to exclude weapons like Microlaser and Flower Vase, but include Lifeguard Wraps (38% at OB0).
+* We do not consider Ultimate Weapons; they're usually not a reliable way of keeping buffs/debuffs applied throughout a battle.
+* We consider "Healing Weapons" as weapons that have either a `All (Cure Spells)` S. Ability or a C. Ability that heals for at least 30 (@(ref:heal-threshold)).
+    * This last criterion is used to exclude weapons like Microlaser and Flower Vase, but include Lifeguard Wraps (38% at OB0).
 * We don't discard teams that are superset of other teams.
     * Say you filter by `PATK Up All + MATK Up All`. Among the possible teams, you'll find these:
         1. Cait Sith with X
@@ -20,8 +20,8 @@
     * At first it might seem like the 2nd team is redundant: if Cait Sith can do it all with one
     weapon, why force Barret into your team?
       However, Cait's weapon may have high potency for `PATK Up` and low potency for `MATK Up`, whereas Barret's might have high `MATK Up`, in which case it makes sense to have both.
-* When sorting the possible teams, the highest criterium is to have as high potency as possible.
-  Fitting many effects into fewer characters is an important criterium, but not as important as having high potency.
+* When sorting the possible teams, the highest criterion is to have as high potency as possible.
+  Fitting many effects into fewer characters is an important criterion, but not as important as having high potency.
   E.g. Cait Sith's Trumpet Shell can technically do `PATK Up All + MATK Up All`, but it's terrible at both.
   So having 2 characters with 1 weapon each, with high potency, is better than running Cait's Trumpet Shell.
 * By default, we ignore event weapons, since their effects have usually low potency.

--- a/snaps/grouped_weapons.snap
+++ b/snaps/grouped_weapons.snap
@@ -6,7 +6,12 @@
         "weaponName": "Bahamut Rod",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -14,7 +19,12 @@
         "weaponName": "Crimson Staff",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -22,7 +32,12 @@
         "weaponName": "Egg Staff",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -30,7 +45,12 @@
         "weaponName": "Fairy Tale",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -38,7 +58,12 @@
         "weaponName": "Festive Rod",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -46,7 +71,12 @@
         "weaponName": "Floral Wand",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -54,7 +84,12 @@
         "weaponName": "Gambanteinn",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -62,7 +97,12 @@
         "weaponName": "Gorgeous Staff",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -70,7 +110,12 @@
         "weaponName": "Kamura Wand",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -78,7 +123,12 @@
         "weaponName": "Lightning's Rod",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -86,7 +136,12 @@
         "weaponName": "Rousing Wizer Staff",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -94,7 +149,12 @@
         "weaponName": "Snowflake",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -102,7 +162,12 @@
         "weaponName": "Staff of the Possessed",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -110,7 +175,12 @@
         "weaponName": "Supreme Sage's Staff",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -118,7 +188,12 @@
         "weaponName": "Terra's Rod",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -126,10 +201,20 @@
         "weaponName": "Umbrella",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           },
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -137,7 +222,12 @@
         "weaponName": "Microlaser",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -145,7 +235,12 @@
         "weaponName": "Crystal Sword",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -153,7 +248,12 @@
         "weaponName": "Tranquilizer Gun",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -161,7 +261,12 @@
         "weaponName": "Bramble Spine",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -169,7 +274,12 @@
         "weaponName": "Centipede",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -177,7 +287,12 @@
         "weaponName": "Deroplatys",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -185,7 +300,12 @@
         "weaponName": "Desperado Rapier",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -193,7 +313,12 @@
         "weaponName": "Espee Rapiere Next-G",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -201,7 +326,12 @@
         "weaponName": "Foam Sword",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -209,7 +339,12 @@
         "weaponName": "Luminary Sword",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -217,7 +352,12 @@
         "weaponName": "Nautilus Spiral",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -225,7 +365,12 @@
         "weaponName": "Physician's Scalpel",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -233,7 +378,12 @@
         "weaponName": "Prime Number",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -241,7 +391,12 @@
         "weaponName": "Syringe Rapier",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -249,7 +404,12 @@
         "weaponName": "Brilliant Collar",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -257,7 +417,12 @@
         "weaponName": "Headphones",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -265,7 +430,12 @@
         "weaponName": "Pilot's Collar",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -273,7 +443,12 @@
         "weaponName": "Pirate Collar",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -281,7 +456,12 @@
         "weaponName": "Rubber Collar",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -289,7 +469,12 @@
         "weaponName": "Silver Collar",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -297,7 +482,12 @@
         "weaponName": "Grand Gloves",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -305,7 +495,12 @@
         "weaponName": "Lifeguard Wraps",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -313,7 +508,12 @@
         "weaponName": "Enhance Sword (Z)",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -321,7 +521,12 @@
         "weaponName": "Twinkling Star",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -334,7 +539,12 @@
         "weaponName": "Festive Blade",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -342,7 +552,12 @@
         "weaponName": "Gargantuan Monolith",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -350,7 +565,12 @@
         "weaponName": "Inflatable Buster Sword",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -358,7 +578,12 @@
         "weaponName": "Mythril Slasher",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -366,7 +591,12 @@
         "weaponName": "Orchard Shovel",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -374,7 +604,12 @@
         "weaponName": "Tranquility",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -382,7 +617,12 @@
         "weaponName": "Type-90 Longsword",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -390,7 +630,12 @@
         "weaponName": "Fafnir Rifle",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -398,7 +643,12 @@
         "weaponName": "Blade of Ruin",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -406,7 +656,12 @@
         "weaponName": "Pirate's Glaive",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       }
@@ -419,7 +674,12 @@
         "weaponName": "Greatsword (A)",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -427,7 +687,12 @@
         "weaponName": "Greatsword of the Worthy",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -435,7 +700,12 @@
         "weaponName": "Shinra Greatsword: Model I",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -443,7 +713,12 @@
         "weaponName": "Tranquility",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -451,7 +726,12 @@
         "weaponName": "Volcanic Heat",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -459,7 +739,12 @@
         "weaponName": "Fafnir Rifle",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -467,7 +752,12 @@
         "weaponName": "Max Ray",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -475,7 +765,12 @@
         "weaponName": "Teacher's Paper Fan",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -483,7 +778,12 @@
         "weaponName": "Desperado Glaive",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -491,7 +791,12 @@
         "weaponName": "Patissier's Glaive",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -499,7 +804,12 @@
         "weaponName": "Pirate's Glaive",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -507,7 +817,12 @@
         "weaponName": "Stream Slasher",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -520,7 +835,12 @@
         "weaponName": "Gambanteinn",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -546,7 +866,12 @@
         "weaponName": "Kamura Wand",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -572,7 +897,12 @@
         "weaponName": "Mermaid Rod",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -598,7 +928,12 @@
         "weaponName": "Rousing Wizer Staff",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -624,7 +959,12 @@
         "weaponName": "Striking Staff",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -650,7 +990,12 @@
         "weaponName": "Master Tonberry's Blade",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -676,7 +1021,12 @@
         "weaponName": "Stalwart Integrity",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -702,7 +1052,12 @@
         "weaponName": "Max Ray",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -728,7 +1083,12 @@
         "weaponName": "Rhad Cannon",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -754,7 +1114,12 @@
         "weaponName": "Catsmegaphone",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -780,7 +1145,12 @@
         "weaponName": "Cool Cat's Megaphone",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -806,7 +1176,12 @@
         "weaponName": "Marching Horn",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -832,7 +1207,12 @@
         "weaponName": "Quina Megaphone",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -858,7 +1238,12 @@
         "weaponName": "Trumpet Shell",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -884,7 +1269,12 @@
         "weaponName": "Scimitar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -910,7 +1300,12 @@
         "weaponName": "Chevron Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -936,7 +1331,12 @@
         "weaponName": "Glavenus Sword",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -962,7 +1362,12 @@
         "weaponName": "Pumpkin Lamppost",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -988,7 +1393,12 @@
         "weaponName": "Bramble Spine",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1014,7 +1424,12 @@
         "weaponName": "Deroplatys",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1040,7 +1455,12 @@
         "weaponName": "Desperado Rapier",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1066,7 +1486,12 @@
         "weaponName": "Giant Fork",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -1092,7 +1517,12 @@
         "weaponName": "Immaculate Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1118,7 +1548,12 @@
         "weaponName": "Shinra Military Sword",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -1144,7 +1579,12 @@
         "weaponName": "Amarant's Claws",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1170,7 +1610,12 @@
         "weaponName": "Class President's Bracelet",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1196,7 +1641,12 @@
         "weaponName": "Demon's Impetus",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1222,7 +1672,12 @@
         "weaponName": "Oven Mitts",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -1248,7 +1703,12 @@
         "weaponName": "Sabin's Claws",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1274,7 +1734,12 @@
         "weaponName": "Work Gloves",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1300,7 +1765,12 @@
         "weaponName": "Rhad Gun",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -1326,7 +1796,12 @@
         "weaponName": "Arctic Star",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1347,7 +1822,12 @@
             }
           },
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1373,7 +1853,12 @@
         "weaponName": "Ceremonial Sword (Z)",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1399,7 +1884,12 @@
         "weaponName": "Surfer Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1430,7 +1920,12 @@
         "weaponName": "Citric Wand",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1456,7 +1951,12 @@
         "weaponName": "Crimson Staff",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1482,7 +1982,12 @@
         "weaponName": "Garnet's Rod",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1508,7 +2013,12 @@
         "weaponName": "Gargantuan Monolith",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1534,7 +2044,12 @@
         "weaponName": "Escutcheon Cannon",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1560,7 +2075,12 @@
         "weaponName": "Microlaser",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1586,7 +2106,12 @@
         "weaponName": "Flower Vase",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1612,7 +2137,12 @@
         "weaponName": "Trumpet Shell",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -1638,7 +2168,12 @@
         "weaponName": "Scimitar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1664,7 +2199,12 @@
         "weaponName": "Full Throttle",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1690,7 +2230,12 @@
         "weaponName": "Garish Greatblade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1716,7 +2261,12 @@
         "weaponName": "Patissier's Glaive",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1742,7 +2292,12 @@
         "weaponName": "Luminary Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1768,7 +2323,12 @@
         "weaponName": "Brilliant Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1794,7 +2354,12 @@
         "weaponName": "Pirate Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1820,7 +2385,12 @@
         "weaponName": "Aonibi",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1846,7 +2416,12 @@
         "weaponName": "Pandemonic Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1872,7 +2447,12 @@
         "weaponName": "Osafune",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1898,7 +2478,12 @@
         "weaponName": "Bahamut Fangs",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1924,7 +2509,12 @@
         "weaponName": "Bunny Gloves",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -1950,7 +2540,12 @@
         "weaponName": "Kirin Gloves",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -1976,7 +2571,12 @@
         "weaponName": "Sabin's Claws",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2002,7 +2602,12 @@
         "weaponName": "Galian Roar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2028,7 +2633,12 @@
         "weaponName": "Sawed-Off GS",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2054,7 +2664,12 @@
         "weaponName": "Crystal Cross",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2080,7 +2695,12 @@
         "weaponName": "Stream Guard",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -2111,7 +2731,12 @@
         "weaponName": "Bahamut Rod",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -2137,7 +2762,12 @@
         "weaponName": "Lightning's Rod",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2163,7 +2793,12 @@
         "weaponName": "Mythril Rod",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -2189,7 +2824,12 @@
         "weaponName": "Greatsword of the Worthy",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2215,7 +2855,12 @@
         "weaponName": "Inflatable Buster Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2241,7 +2886,12 @@
         "weaponName": "Lightning's Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -2267,7 +2917,12 @@
         "weaponName": "Stalwart Integrity",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2293,7 +2948,12 @@
         "weaponName": "Assault Gun",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2319,7 +2979,12 @@
         "weaponName": "Fafnir Rifle",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2345,7 +3010,12 @@
         "weaponName": "Lefko Kypseli",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2371,7 +3041,12 @@
         "weaponName": "Sunrise Cannon",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2397,7 +3072,12 @@
         "weaponName": "Crystal Megaphone",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2423,7 +3103,12 @@
         "weaponName": "Quina Megaphone",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2449,7 +3134,12 @@
         "weaponName": "Slash Lance",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2475,7 +3165,12 @@
         "weaponName": "Viper Halberd",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2501,7 +3196,12 @@
         "weaponName": "Butterfly Edge",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2527,7 +3227,12 @@
         "weaponName": "Hardcore Squad",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -2553,7 +3258,12 @@
         "weaponName": "Rest in Peace",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2579,7 +3289,12 @@
         "weaponName": "Centipede",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2605,7 +3320,12 @@
         "weaponName": "Syringe Rapier",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2631,7 +3351,12 @@
         "weaponName": "Mythril Type-0 Katana",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2657,7 +3382,12 @@
         "weaponName": "Torn Wing",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2683,7 +3413,12 @@
         "weaponName": "Work Gloves",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2709,7 +3444,12 @@
         "weaponName": "Watch of the Hunt",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2735,7 +3475,12 @@
         "weaponName": "Defender",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2766,7 +3511,12 @@
         "weaponName": "Chocobo Staff",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2792,7 +3542,12 @@
         "weaponName": "Gorgeous Staff",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2818,7 +3573,12 @@
         "weaponName": "Guard Stick",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2844,7 +3604,12 @@
         "weaponName": "Kamura Wand",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2870,7 +3635,12 @@
         "weaponName": "Mythril Rod",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -2896,7 +3666,12 @@
         "weaponName": "Rousing Wizer Staff",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2922,7 +3697,12 @@
         "weaponName": "Gargantuan Monolith",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2948,7 +3728,12 @@
         "weaponName": "Greatsword of the Worthy",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -2974,7 +3759,12 @@
         "weaponName": "Escutcheon Cannon",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3000,7 +3790,12 @@
         "weaponName": "Heavy Vulcan",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3026,7 +3821,12 @@
         "weaponName": "Battle Trumpet",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3052,7 +3852,12 @@
         "weaponName": "Viper Halberd",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3078,7 +3883,12 @@
         "weaponName": "Bandaged Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3104,7 +3914,12 @@
         "weaponName": "Hardcore Squad",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -3130,7 +3945,12 @@
         "weaponName": "Snow's Bardiche",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3156,7 +3976,12 @@
         "weaponName": "Pumpkin Blaster",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3182,7 +4007,12 @@
         "weaponName": "SSR1976",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3208,7 +4038,12 @@
         "weaponName": "Core Defender",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3234,7 +4069,12 @@
         "weaponName": "Deroplatys",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3260,7 +4100,12 @@
         "weaponName": "Physician's Scalpel",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3286,7 +4131,12 @@
         "weaponName": "Syringe Rapier",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3312,7 +4162,12 @@
         "weaponName": "Pilot's Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3338,7 +4193,12 @@
         "weaponName": "Sleek Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3364,7 +4224,12 @@
         "weaponName": "Overture",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3390,7 +4255,12 @@
         "weaponName": "Sawed-Off GS",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3416,7 +4286,12 @@
         "weaponName": "Bahamut Cutter",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3442,7 +4317,12 @@
         "weaponName": "Zenithian Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3473,7 +4353,12 @@
         "weaponName": "Grinding Gear",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3481,7 +4366,12 @@
         "weaponName": "Stream Saber",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3489,7 +4379,12 @@
         "weaponName": "Umbralschwert",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3497,7 +4392,12 @@
         "weaponName": "Pirate's Glaive",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3505,7 +4405,12 @@
         "weaponName": "Killer Falcon",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3513,7 +4418,12 @@
         "weaponName": "Cerulean Sky",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3521,7 +4431,12 @@
         "weaponName": "Overture",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3529,7 +4444,12 @@
         "weaponName": "Muramasa",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3537,7 +4457,12 @@
         "weaponName": "Feathered Gloves",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -3550,7 +4475,12 @@
         "weaponName": "Mystic Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "ExtraHigh",
@@ -3576,7 +4506,12 @@
         "weaponName": "Infiltration Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "ExtraHigh",
@@ -3602,7 +4537,12 @@
         "weaponName": "Leather Combat Gloves",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "ExtraHigh",
@@ -3628,7 +4568,12 @@
         "weaponName": "Shortbarrel",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "ExtraHigh",
@@ -3654,7 +4599,12 @@
         "weaponName": "Heirloom Brush",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "ExtraHigh",
@@ -3685,7 +4635,12 @@
         "weaponName": "Fusion Sword",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -3693,7 +4648,12 @@
         "weaponName": "Phoenix Odachi",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3701,7 +4661,12 @@
         "weaponName": "Transgressor",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -3709,7 +4674,12 @@
         "weaponName": "Bird of Prey",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -3717,7 +4687,12 @@
         "weaponName": "Surfer Blade",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -3730,7 +4705,12 @@
         "weaponName": "Fusion Sword",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -3738,7 +4718,12 @@
         "weaponName": "Garish Greatblade",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3746,7 +4731,12 @@
         "weaponName": "Patissier's Collar",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3754,7 +4744,12 @@
         "weaponName": "Phoenix Odachi",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3762,7 +4757,12 @@
         "weaponName": "Starsoul Blade",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -3775,7 +4775,12 @@
         "weaponName": "Festive Rod",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3783,7 +4788,12 @@
         "weaponName": "Fafnir Rifle",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3791,7 +4801,12 @@
         "weaponName": "Kikuichimonji",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3799,7 +4814,12 @@
         "weaponName": "Demon's Impetus",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       }
@@ -3812,7 +4832,12 @@
         "weaponName": "Festive Rod",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3820,7 +4845,12 @@
         "weaponName": "Lightning's Rod",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -3828,7 +4858,12 @@
         "weaponName": "Kikuichimonji",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -3841,7 +4876,12 @@
         "weaponName": "Gambanteinn",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3867,7 +4907,12 @@
         "weaponName": "Locke's Sword",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3893,7 +4938,12 @@
         "weaponName": "Shinra Ceremonial Rifle",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3919,7 +4969,12 @@
         "weaponName": "Luminary Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3945,7 +5000,12 @@
         "weaponName": "Striped Moogle Float",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -3976,7 +5036,12 @@
         "weaponName": "Citric Wand",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4002,7 +5067,12 @@
         "weaponName": "Scimitar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4028,7 +5098,12 @@
         "weaponName": "Locke's Sword",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4054,7 +5129,12 @@
         "weaponName": "Desperado Rifle",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4080,7 +5160,12 @@
         "weaponName": "Gelid Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4111,7 +5196,12 @@
         "weaponName": "Mermaid Rod",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4137,7 +5227,12 @@
         "weaponName": "Festive Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4163,7 +5258,12 @@
         "weaponName": "Locke's Sword",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4189,7 +5289,12 @@
         "weaponName": "Pirate Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4215,7 +5320,12 @@
         "weaponName": "Winged Chakram",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4246,7 +5356,12 @@
         "weaponName": "Ghost Ensis",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4272,7 +5387,12 @@
         "weaponName": "Grinding Gear",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4298,7 +5418,12 @@
         "weaponName": "Mad Minute",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4324,7 +5449,12 @@
         "weaponName": "Gauntlets of the Worthy",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4350,7 +5480,12 @@
         "weaponName": "Kugelblitz",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4381,7 +5516,12 @@
         "weaponName": "Team Leader's Bamboo Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -4407,7 +5547,12 @@
         "weaponName": "Slay the Day",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4433,7 +5578,12 @@
         "weaponName": "Physician's Scalpel",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4459,7 +5609,12 @@
         "weaponName": "Overture",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4485,7 +5640,12 @@
         "weaponName": "Feathered Gloves",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4516,7 +5676,12 @@
         "weaponName": "Teacher's Paper Fan",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4542,7 +5707,12 @@
         "weaponName": "Brilliant Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4568,7 +5738,12 @@
         "weaponName": "Shinra Military Sword",
         "ranges": [
           {
-            "range": "Self",
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4599,7 +5774,12 @@
         "weaponName": "Sunrise Cannon",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4630,7 +5810,12 @@
         "weaponName": "Sunrise Cannon",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4656,7 +5841,12 @@
         "weaponName": "Desperado Rapier",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4687,7 +5877,12 @@
         "weaponName": "Desperado Rapier",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -4718,7 +5913,12 @@
         "weaponName": "Gorgeous Staff",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4726,7 +5926,12 @@
         "weaponName": "Killer Falcon",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4734,7 +5939,12 @@
         "weaponName": "Chrome Death Penalty",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4747,7 +5957,12 @@
         "weaponName": "Sōba",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4760,7 +5975,12 @@
         "weaponName": "Festive Blade",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4773,7 +5993,12 @@
         "weaponName": "Cruel Successor",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4781,7 +6006,12 @@
         "weaponName": "Elegant Gloves",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4789,7 +6019,12 @@
         "weaponName": "Chrome Death Penalty",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4802,7 +6037,12 @@
         "weaponName": "Staff of the Possessed",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4815,7 +6055,12 @@
         "weaponName": "Chevron Blade",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4823,7 +6068,12 @@
         "weaponName": "Chrome Death Penalty",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4836,7 +6086,12 @@
         "weaponName": "Gorgeous Staff",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4844,7 +6099,12 @@
         "weaponName": "Shiranui",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4857,7 +6117,12 @@
         "weaponName": "Patissier's Spear",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4865,7 +6130,12 @@
         "weaponName": "Crimson Blitz",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4873,7 +6143,12 @@
         "weaponName": "Omega Wing",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4886,7 +6161,12 @@
         "weaponName": "Antler Pike",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4899,7 +6179,12 @@
         "weaponName": "Uber 4-Point Shuriken",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4912,7 +6197,12 @@
         "weaponName": "Battering Sword",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }
@@ -4925,7 +6215,12 @@
         "weaponName": "Cool Cat's Megaphone",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -4933,7 +6228,12 @@
         "weaponName": "Grinding Gear",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4941,7 +6241,12 @@
         "weaponName": "Rocket Lance",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -4949,7 +6254,12 @@
         "weaponName": "Erdrick's Sword",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4957,7 +6267,12 @@
         "weaponName": "Umbralschwert",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -4965,7 +6280,12 @@
         "weaponName": "Snow's Bardiche",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -4973,7 +6293,12 @@
         "weaponName": "Shinra Ceremonial Rifle",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -4981,7 +6306,12 @@
         "weaponName": "Patissier's Collar",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -4989,7 +6319,12 @@
         "weaponName": "Cerulean Sky",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -4997,7 +6332,12 @@
         "weaponName": "Serrated Remiges",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -5005,7 +6345,12 @@
         "weaponName": "Shinra Blade: Model I",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -5013,7 +6358,12 @@
         "weaponName": "Omega Wing",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -5021,7 +6371,12 @@
         "weaponName": "Leather Combat Gloves",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -5029,7 +6384,12 @@
         "weaponName": "Shining Gloves",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -5037,7 +6397,12 @@
         "weaponName": "Galian Roar",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -5045,7 +6410,12 @@
         "weaponName": "Fatum Ex Machina",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       }
@@ -5058,7 +6428,12 @@
         "weaponName": "Flayer",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -5066,7 +6441,12 @@
         "weaponName": "Mop",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -5074,7 +6454,12 @@
         "weaponName": "Spear",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -5082,7 +6467,12 @@
         "weaponName": "Trident",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       }
@@ -5095,7 +6485,12 @@
         "weaponName": "Supreme Sage's Staff",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -5103,7 +6498,12 @@
         "weaponName": "Dragoon Lance",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -5111,7 +6511,12 @@
         "weaponName": "Fusion Sword",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -5119,7 +6524,12 @@
         "weaponName": "Blade of the Worthy",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -5127,7 +6537,12 @@
         "weaponName": "Infiltration Sword",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -5135,7 +6550,12 @@
         "weaponName": "Blue Daffodil Gloves",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -5143,7 +6563,12 @@
         "weaponName": "Lightning's Gloves",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -5151,7 +6576,12 @@
         "weaponName": "Transgressor",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -5159,7 +6589,12 @@
         "weaponName": "Bird of Prey",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -5167,7 +6602,12 @@
         "weaponName": "Rocker's Guitar",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -5175,7 +6615,12 @@
         "weaponName": "Festive Sword",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       },
@@ -5183,7 +6628,12 @@
         "weaponName": "Sword of the Hunt",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "Self",
+              "ob10": "Self",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       }
@@ -5196,7 +6646,12 @@
         "weaponName": "Physician's Scalpel",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "ExtraHigh",
@@ -5222,7 +6677,12 @@
         "weaponName": "Chrome Death Penalty",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "ExtraHigh",
@@ -5253,7 +6713,12 @@
         "weaponName": "Noble Parasol",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       },
@@ -5261,7 +6726,12 @@
         "weaponName": "Festive Sword",
         "ranges": [
           {
-            "range": "Self"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "Self",
+              "ob0": "Self"
+            }
           }
         ]
       }
@@ -5274,7 +6744,12 @@
         "weaponName": "Full Metal Staff",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5300,7 +6775,12 @@
         "weaponName": "Noblesse Rod",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5326,7 +6806,12 @@
         "weaponName": "Lightning's Sword",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5352,7 +6837,12 @@
         "weaponName": "Turks' Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5378,7 +6868,12 @@
         "weaponName": "Type-91 Two-Hander",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5404,7 +6899,12 @@
         "weaponName": "Electrocannon",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5430,7 +6930,12 @@
         "weaponName": "Battle Trumpet",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5456,7 +6961,12 @@
         "weaponName": "Spirit Demon Megaphone",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5482,7 +6992,12 @@
         "weaponName": "Patissier's Spear",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5508,7 +7023,12 @@
         "weaponName": "Pole Axe",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5534,7 +7054,12 @@
         "weaponName": "Iron Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5560,7 +7085,12 @@
         "weaponName": "Mystic Sword",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5586,7 +7116,12 @@
         "weaponName": "Desperado Glaive",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5612,7 +7147,12 @@
         "weaponName": "Rest in Peace",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5638,7 +7178,12 @@
         "weaponName": "Steiner's Blade",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5664,7 +7209,12 @@
         "weaponName": "Featherscatter",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5690,7 +7240,12 @@
         "weaponName": "Marine Shooter",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5716,7 +7271,12 @@
         "weaponName": "Spirit Demon Rifle",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5742,7 +7302,12 @@
         "weaponName": "Dragontail Sword",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5768,7 +7333,12 @@
         "weaponName": "Slick Beetle",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5794,7 +7364,12 @@
         "weaponName": "Steward Collar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -5820,7 +7395,12 @@
         "weaponName": "Infiltration Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5846,7 +7426,12 @@
         "weaponName": "Kuja's Spirit Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5872,7 +7457,12 @@
         "weaponName": "Northern Lights",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5898,7 +7488,12 @@
         "weaponName": "Pandemonic Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5924,7 +7519,12 @@
         "weaponName": "Shinra Blade: Model I",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5950,7 +7550,12 @@
         "weaponName": "Kotetsu",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -5976,7 +7581,12 @@
         "weaponName": "Leather Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6002,7 +7612,12 @@
         "weaponName": "Lightning's Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6028,7 +7643,12 @@
         "weaponName": "Shining Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6054,7 +7674,12 @@
         "weaponName": "Steward Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6080,7 +7705,12 @@
         "weaponName": "Noblesse Automatic",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6106,7 +7736,12 @@
         "weaponName": "S1976C",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6132,7 +7767,12 @@
         "weaponName": "4-Point Shuriken",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6158,7 +7798,12 @@
         "weaponName": "Fatum Ex Machina",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6184,7 +7829,12 @@
         "weaponName": "Watch of the Hunt",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6215,7 +7865,12 @@
         "weaponName": "Magatsuchi Rod",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6241,7 +7896,12 @@
         "weaponName": "Type-91 Two-Hander",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6267,7 +7927,12 @@
         "weaponName": "Electrocannon",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6293,7 +7958,12 @@
         "weaponName": "Solid Bazooka",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6319,7 +7989,12 @@
         "weaponName": "Battle Trumpet",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6345,7 +8020,12 @@
         "weaponName": "Gold Megaphone",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6371,7 +8051,12 @@
         "weaponName": "Pole Axe",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6397,7 +8082,12 @@
         "weaponName": "Erdrick's Sword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6423,7 +8113,12 @@
         "weaponName": "Mystic Sword",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6449,7 +8144,12 @@
         "weaponName": "Snow's Bardiche",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6475,7 +8175,12 @@
         "weaponName": "Mad Minute",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6501,7 +8206,12 @@
         "weaponName": "Junk Collar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6527,7 +8237,12 @@
         "weaponName": "Kuja's Spirit Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6553,7 +8268,12 @@
         "weaponName": "Kotetsu",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6579,7 +8299,12 @@
         "weaponName": "Amarant's Claws",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6605,7 +8330,12 @@
         "weaponName": "Guide Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6631,7 +8361,12 @@
         "weaponName": "Shining Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6657,7 +8392,12 @@
         "weaponName": "Striped Moogle Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6683,7 +8423,12 @@
         "weaponName": "Tiger Fangs",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6709,7 +8454,12 @@
         "weaponName": "S1976C",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6735,7 +8485,12 @@
         "weaponName": "Striped Moogle Flag",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6761,7 +8516,12 @@
         "weaponName": "Magatsuchi Blade",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6787,7 +8547,12 @@
         "weaponName": "Twinkling Star",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6818,7 +8583,12 @@
         "weaponName": "Dawn's Prayers",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6844,7 +8614,12 @@
         "weaponName": "Floral Wand",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6870,7 +8645,12 @@
         "weaponName": "Sun Umbrella",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6896,7 +8676,12 @@
         "weaponName": "Greatsword (A)",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6922,7 +8707,12 @@
         "weaponName": "Quad Gatling Gun",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -6948,7 +8738,12 @@
         "weaponName": "W Machine",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -6974,7 +8769,12 @@
         "weaponName": "Silver Megaphone",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Low",
@@ -6995,7 +8795,12 @@
             }
           },
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7021,7 +8826,12 @@
         "weaponName": "Captain's Spear",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7047,7 +8857,12 @@
         "weaponName": "Glavenus Sword",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7073,7 +8888,12 @@
         "weaponName": "Hardedge",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7099,7 +8919,12 @@
         "weaponName": "Sleek Saber",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7125,7 +8950,12 @@
         "weaponName": "Best Wishes",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7151,7 +8981,12 @@
         "weaponName": "Piece of Cake",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7177,7 +9012,12 @@
         "weaponName": "Set Square",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7203,7 +9043,12 @@
         "weaponName": "Slay the Day",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7229,7 +9074,12 @@
         "weaponName": "Stream Slasher",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7255,7 +9105,12 @@
         "weaponName": "Desperado Rifle",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7281,7 +9136,12 @@
         "weaponName": "Nightjar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7307,7 +9167,12 @@
         "weaponName": "Rifle of the Hunt",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7333,7 +9198,12 @@
         "weaponName": "Turks' Rifle",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7359,7 +9229,12 @@
         "weaponName": "Great Sabrecat Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7385,7 +9260,12 @@
         "weaponName": "Iron Collar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7411,7 +9291,12 @@
         "weaponName": "Cerulean Sky",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7437,7 +9322,12 @@
         "weaponName": "Folding Ruler",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7463,7 +9353,12 @@
         "weaponName": "Overture",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7489,7 +9384,12 @@
         "weaponName": "Radiant Edge",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7515,7 +9415,12 @@
         "weaponName": "Class President's Bracelet",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7541,7 +9446,12 @@
         "weaponName": "Járngreipr",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7567,7 +9477,12 @@
         "weaponName": "Turks' Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7593,7 +9508,12 @@
         "weaponName": "Hawkeye",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7619,7 +9539,12 @@
         "weaponName": "Winged Chakram",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7645,7 +9570,12 @@
         "weaponName": "Black Whiskers",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7671,7 +9601,12 @@
         "weaponName": "Cutlass",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7697,7 +9632,12 @@
         "weaponName": "Iron Greatsword",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7723,7 +9663,12 @@
         "weaponName": "Surfer Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7749,7 +9694,12 @@
         "weaponName": "Twinkling Star",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7780,7 +9730,12 @@
         "weaponName": "Crimson Staff",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7806,7 +9761,12 @@
         "weaponName": "Snowflake",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7832,7 +9792,12 @@
         "weaponName": "Sun Umbrella",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7858,7 +9823,12 @@
         "weaponName": "Hell House Cannon",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7884,7 +9854,12 @@
         "weaponName": "Nocturne Horn",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7910,7 +9885,12 @@
         "weaponName": "Witch's Broom",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7936,7 +9916,12 @@
         "weaponName": "Full Throttle",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -7962,7 +9947,12 @@
         "weaponName": "Nightjar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -7988,7 +9978,12 @@
         "weaponName": "Rose Musket",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8014,7 +10009,12 @@
         "weaponName": "Thunderbird",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8040,7 +10040,12 @@
         "weaponName": "Stingray",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8066,7 +10071,12 @@
         "weaponName": "Canyon Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8092,7 +10102,12 @@
         "weaponName": "Gold Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8118,7 +10133,12 @@
         "weaponName": "Great Sabrecat Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8144,7 +10164,12 @@
         "weaponName": "Hell House Collar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8170,7 +10195,12 @@
         "weaponName": "Nameless",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8196,7 +10226,12 @@
         "weaponName": "Protector's Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8222,7 +10257,12 @@
         "weaponName": "Starsoul Blade",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8248,7 +10288,12 @@
         "weaponName": "Feathered Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8274,7 +10319,12 @@
         "weaponName": "Kaiser Knuckles",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8300,7 +10350,12 @@
         "weaponName": "Galian Roar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8326,7 +10381,12 @@
         "weaponName": "Kugelblitz",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8352,7 +10412,12 @@
         "weaponName": "Holiday Bell",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8378,7 +10443,12 @@
         "weaponName": "Arc Sword",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8404,7 +10474,12 @@
         "weaponName": "Stream Guard",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8435,7 +10510,12 @@
         "weaponName": "Snow's Bardiche",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8461,7 +10541,12 @@
         "weaponName": "Nautilus Spiral",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8492,7 +10577,12 @@
         "weaponName": "Striking Staff",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8523,7 +10613,12 @@
         "weaponName": "Shortbarrel",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8554,7 +10649,12 @@
         "weaponName": "Terra's Rod",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8580,7 +10680,12 @@
         "weaponName": "Volcanic Heat",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8606,7 +10711,12 @@
         "weaponName": "Sharkslayer",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8632,7 +10742,12 @@
         "weaponName": "Gold Megaphone",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8658,7 +10773,12 @@
         "weaponName": "Chocobo Paddle",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8684,7 +10804,12 @@
         "weaponName": "Patissier's Glaive",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8710,7 +10835,12 @@
         "weaponName": "Marine Shooter",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8736,7 +10866,12 @@
         "weaponName": "Flame Dragon's Band",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8762,7 +10897,12 @@
         "weaponName": "Ivy Collar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8788,7 +10928,12 @@
         "weaponName": "Flame Dragon Blade",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8814,7 +10959,12 @@
         "weaponName": "Radiant Edge",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8840,7 +10990,12 @@
         "weaponName": "Shinra Wyvern Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8866,7 +11021,12 @@
         "weaponName": "Withering Blaze",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8892,7 +11052,12 @@
         "weaponName": "Guide Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8918,7 +11083,12 @@
         "weaponName": "Boomerang",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -8944,7 +11114,12 @@
         "weaponName": "Mallet of Luck",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -8975,7 +11150,12 @@
         "weaponName": "Terra's Rod",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9001,7 +11181,12 @@
         "weaponName": "Icebolt Megaphone",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9027,7 +11212,12 @@
         "weaponName": "Stilva Megaphone",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9053,7 +11243,12 @@
         "weaponName": "Rocket Lance",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9079,7 +11274,12 @@
         "weaponName": "Neo Bahamut Greatsword",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9105,7 +11305,12 @@
         "weaponName": "Stilva Glaive",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9131,7 +11336,12 @@
         "weaponName": "Bald Eagle",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9157,7 +11367,12 @@
         "weaponName": "Nautilus Spiral",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9183,7 +11398,12 @@
         "weaponName": "Ivy Collar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9209,7 +11429,12 @@
         "weaponName": "Lightning's Gloves",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9235,7 +11460,12 @@
         "weaponName": "Icebolt Shooter",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9261,7 +11491,12 @@
         "weaponName": "Pinwheel",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9287,7 +11522,12 @@
         "weaponName": "Gelid Sword",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9313,7 +11553,12 @@
         "weaponName": "Pressure Ridge",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9344,7 +11589,12 @@
         "weaponName": "Terra's Rod",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9370,7 +11620,12 @@
         "weaponName": "Icebolt Megaphone",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9396,7 +11651,12 @@
         "weaponName": "Witch's Broom",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9422,7 +11682,12 @@
         "weaponName": "Dragoon Lance",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9448,7 +11713,12 @@
         "weaponName": "Nautilus Spiral",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9474,7 +11744,12 @@
         "weaponName": "Seaside Collar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9500,7 +11775,12 @@
         "weaponName": "Icebolt Shooter",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9526,7 +11806,12 @@
         "weaponName": "Wind Slash",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9557,7 +11842,12 @@
         "weaponName": "Ghost Ensis",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9583,7 +11873,12 @@
         "weaponName": "Shinra Greatsword: Model I",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9609,7 +11904,12 @@
         "weaponName": "Desperado Glaive",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9635,7 +11935,12 @@
         "weaponName": "Rifle of the Hunt",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9661,7 +11966,12 @@
         "weaponName": "Hrotti",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9687,7 +11997,12 @@
         "weaponName": "Blue Bramble",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9713,7 +12028,12 @@
         "weaponName": "Immaculate Blade",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9739,7 +12059,12 @@
         "weaponName": "Chiron",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9765,7 +12090,12 @@
         "weaponName": "Fatum Ex Machina",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9791,7 +12121,12 @@
         "weaponName": "Risanautr",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9817,7 +12152,12 @@
         "weaponName": "Virtuous Contract",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9848,7 +12188,12 @@
         "weaponName": "Sea Dragon Staff",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9874,7 +12219,12 @@
         "weaponName": "Staff of the Possessed",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9900,7 +12250,12 @@
         "weaponName": "Mythril Slasher",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9926,7 +12281,12 @@
         "weaponName": "Sea Dragon Greatsword",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -9952,7 +12312,12 @@
         "weaponName": "Sharkslayer",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -9978,7 +12343,12 @@
         "weaponName": "Green Megaphone",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -10004,7 +12374,12 @@
         "weaponName": "Umbralschwert",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -10030,7 +12405,12 @@
         "weaponName": "Revenant Mother's Glaive",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -10056,7 +12436,12 @@
         "weaponName": "Silver Collar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -10082,7 +12467,12 @@
         "weaponName": "Tempest",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -10108,7 +12498,12 @@
         "weaponName": "Black Whiskers",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -10139,7 +12534,12 @@
         "weaponName": "Floral Wand",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -10165,7 +12565,12 @@
         "weaponName": "Teacher's Paper Fan",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -10191,7 +12596,12 @@
         "weaponName": "Nocturne Horn",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -10217,7 +12627,12 @@
         "weaponName": "Silver Collar",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -10243,7 +12658,12 @@
         "weaponName": "Tsviet Collar",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -10269,7 +12689,12 @@
         "weaponName": "Humus Saber",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -10295,7 +12720,12 @@
         "weaponName": "Merciless White",
         "ranges": [
           {
-            "range": "All",
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "Mid",
@@ -10321,7 +12751,12 @@
         "weaponName": "Holiday Bell",
         "ranges": [
           {
-            "range": "SingleTarget",
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            },
             "allPotencies": {
               "ob6": {
                 "max": "High",
@@ -10352,7 +12787,12 @@
         "weaponName": "Zenithian Sword",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       }
@@ -10365,7 +12805,12 @@
         "weaponName": "Crimson Blitz",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       },
@@ -10373,7 +12818,12 @@
         "weaponName": "Gun of the Worthy",
         "ranges": [
           {
-            "range": "SingleTarget"
+            "allRanges": {
+              "ob6": "SingleTarget",
+              "ob10": "SingleTarget",
+              "ob1": "SingleTarget",
+              "ob0": "SingleTarget"
+            }
           }
         ]
       }
@@ -10386,7 +12836,12 @@
         "weaponName": "Inflatable Buster Sword",
         "ranges": [
           {
-            "range": "All"
+            "allRanges": {
+              "ob6": "All",
+              "ob10": "All",
+              "ob1": "All",
+              "ob0": "All"
+            }
           }
         ]
       }

--- a/src/Core/Database.purs
+++ b/src/Core/Database.purs
@@ -719,6 +719,7 @@ groupsForWeapon weapon = do
     where
     inner = case ob0 of
       Heal { percentage } ->
+        -- #(ref:heal-threshold)
         if unwrap percentage >= 30 then Just { effectType: FilterHeal, potencies: Nothing }
         else Nothing
       Veil {} -> Just { effectType: FilterVeil, potencies: Nothing }

--- a/src/Core/Database.purs
+++ b/src/Core/Database.purs
@@ -139,14 +139,14 @@ getDistinctObs weapon = do
 
   -- Two effects are equivalent if they're the same kind of effect with the same
   -- range and potencies. Duration, extension, and percentages are not considered.
-  -- Crashes if `x` and `y` are different kinds of effect: that would mean a weapon's
-  -- effects aren't listed in the same order at every overboost level.
   areWeaponEffectsEquivalent :: WeaponEffect -> WeaponEffect -> Boolean
   areWeaponEffectsEquivalent x y
-    | tagOf x /= tagOf y = crash unit
+    | tagOf x /= tagOf y =
+        -- INVARIANT: We assume a weapon's effects are always listed in the same order at every overboost level.
+        -- This function crashes if that invariant is violated.
+        -- #(ref:effects-same-order)
+        unsafeCrashWith $ "Effects for weapon " <> display weapon.name <> " are not in the same order"
     | otherwise = rangeOf x == rangeOf y && potenciesOf x == potenciesOf y
-
-  crash _ = unsafeCrashWith $ "Effects for weapon " <> display weapon.name <> " are not in the same order"
 
 createDbState :: forall m. MonadEffect m => MonadRec m => Array Weapon -> UserState -> m DbState
 createDbState newWeapons existingUserState = do
@@ -536,6 +536,7 @@ groupsForWeapon weapon = do
   groupsForWeapon' :: ZipList (Maybe GroupEntry)
   groupsForWeapon' = ado
     -- INVARIANT: this assumes weapon effects are listed in the same order at all overboost levels.
+    -- @(ref:effects-same-order)
     ob0 <- ZipList $ LazyList.fromFoldable weapon.ob0.effects
     ob1 <- ZipList $ LazyList.fromFoldable weapon.ob1.effects
     ob6 <- ZipList $ LazyList.fromFoldable weapon.ob6.effects
@@ -597,8 +598,7 @@ groupsForWeapon weapon = do
   -- Only the `effectType` is determined from the OB0 effect.
   --
   -- This assumes effects are listed in the same order at all overboost levels.
-  -- That invariant is enforced by `getDistinctObs` (via `areWeaponEffectsEquivalent`),
-  -- which runs for every weapon and crashes on a mismatch.
+  -- That invariant is enforced here: @(ref:effects-same-order)
   groupForWeaponEffect ob0 ob1 ob6 ob10 =
     effectTypeOf <#> \effectType ->
       { effectType

--- a/src/Core/Database.purs
+++ b/src/Core/Database.purs
@@ -586,6 +586,76 @@ rangeOf = case _ of
   EnhanceDebuffs r -> r.range
   Enliven r -> r.range
 
+-- The potencies of an effect, if it has any.
+-- Some effects have no potencies (e.g. `Heal`, `Provoke`, `Enliven`,
+-- and the percentage-based boosts), in which case this returns `Nothing`.
+potenciesOf :: WeaponEffect -> Maybe Potencies
+potenciesOf = case _ of
+  Heal _ -> Nothing
+  PatkUp r -> Just r.potencies
+  MatkUp r -> Just r.potencies
+  PdefUp r -> Just r.potencies
+  MdefUp r -> Just r.potencies
+  HPGain _ -> Nothing
+  EnhanceBuffs r -> Just r.potencies
+  PhysicalWeaponBoost _ -> Nothing
+  MagicWeaponBoost _ -> Nothing
+  PhysicalDamageBonus _ -> Nothing
+  MagicDamageBonus _ -> Nothing
+  FireDamageUp r -> Just r.potencies
+  IceDamageUp r -> Just r.potencies
+  LightningDamageUp r -> Just r.potencies
+  EarthDamageUp r -> Just r.potencies
+  WaterDamageUp r -> Just r.potencies
+  WindDamageUp r -> Just r.potencies
+  FireWeaponBoost _ -> Nothing
+  IceWeaponBoost _ -> Nothing
+  LightningWeaponBoost _ -> Nothing
+  EarthWeaponBoost _ -> Nothing
+  WaterWeaponBoost _ -> Nothing
+  WindWeaponBoost _ -> Nothing
+  FireDamageBonus _ -> Nothing
+  IceDamageBonus _ -> Nothing
+  LightningDamageBonus _ -> Nothing
+  EarthDamageBonus _ -> Nothing
+  WaterDamageBonus _ -> Nothing
+  WindDamageBonus _ -> Nothing
+  FireResistUp r -> Just r.potencies
+  IceResistUp r -> Just r.potencies
+  LightningResistUp r -> Just r.potencies
+  EarthResistUp r -> Just r.potencies
+  WaterResistUp r -> Just r.potencies
+  WindResistUp r -> Just r.potencies
+  Veil _ -> Nothing
+  Provoke _ -> Nothing
+  PatkDown r -> Just r.potencies
+  MatkDown r -> Just r.potencies
+  PdefDown r -> Just r.potencies
+  MdefDown r -> Just r.potencies
+  FireDamageDown r -> Just r.potencies
+  IceDamageDown r -> Just r.potencies
+  LightningDamageDown r -> Just r.potencies
+  EarthDamageDown r -> Just r.potencies
+  WaterDamageDown r -> Just r.potencies
+  WindDamageDown r -> Just r.potencies
+  FireResistDown r -> Just r.potencies
+  IceResistDown r -> Just r.potencies
+  LightningResistDown r -> Just r.potencies
+  EarthResistDown r -> Just r.potencies
+  WaterResistDown r -> Just r.potencies
+  WindResistDown r -> Just r.potencies
+  FireWeakness _ -> Nothing
+  IceWeakness _ -> Nothing
+  LightningWeakness _ -> Nothing
+  EarthWeakness _ -> Nothing
+  WaterWeakness _ -> Nothing
+  WindWeakness _ -> Nothing
+  Enfeeble _ -> Nothing
+  Stop _ -> Nothing
+  ExploitWeakness _ -> Nothing
+  EnhanceDebuffs r -> Just r.potencies
+  Enliven _ -> Nothing
+
 groupsForWeapon :: Weapon -> List.List GroupEntry
 groupsForWeapon weapon = do
   mergeRanges $ Arr.fold
@@ -706,160 +776,101 @@ groupsForWeapon weapon = do
          , potencies :: Maybe AllPotencies
          , allRanges :: AllRanges
          }
-  -- NOTE: an effect can have a different range at each overboost level
-  -- (e.g. Festive Sword's Enliven is `Self` at OB0/OB1 and `All` at OB6/OB10),
-  -- so we record the range at every level via `rangeOf`.
-  -- The `effectType`/`potencies` are still determined from the OB0 effect.
+  -- NOTE: an effect can have a different range and different potencies at each
+  -- overboost level (e.g. Festive Sword's Enliven is `Self` at OB0/OB1 and `All`
+  -- at OB6/OB10), so we read both from every level via `rangeOf` / `potenciesOf`.
+  -- Only the `effectType` is determined from the OB0 effect.
+  --
+  -- This assumes effects are listed in the same order at all overboost levels.
+  -- That invariant is enforced by `getDistinctObs` (via `areWeaponEffectsEquivalent`),
+  -- which runs for every weapon and crashes on a mismatch.
   groupForWeaponEffect ob0 ob1 ob6 ob10 =
-    inner <#> \{ effectType, potencies } ->
+    effectTypeOf <#> \effectType ->
       { effectType
-      , potencies
+      , potencies: allPotencies
       , allRanges: { ob0: rangeOf ob0, ob1: rangeOf ob1, ob6: rangeOf ob6, ob10: rangeOf ob10 }
       }
     where
-    inner = case ob0 of
-      Heal { percentage } ->
-        -- #(ref:heal-threshold)
-        if unwrap percentage >= 30 then Just { effectType: FilterHeal, potencies: Nothing }
-        else Nothing
-      Veil {} -> Just { effectType: FilterVeil, potencies: Nothing }
-      Provoke {} -> Just { effectType: FilterProvoke, potencies: Nothing }
-      Enfeeble {} -> Just { effectType: FilterEnfeeble, potencies: Nothing }
-      Stop {} -> Just { effectType: FilterStop, potencies: Nothing }
-      ExploitWeakness {} -> Just { effectType: FilterExploitWeakness, potencies: Nothing }
-      Enliven {} -> Just { effectType: FilterEnliven, potencies: Nothing }
-      HPGain {} -> Just { effectType: FilterHPGain, potencies: Nothing }
+    -- `Just` only for effects that have potencies; `Nothing` otherwise.
+    allPotencies = do
+      ob0Potencies <- potenciesOf ob0
+      ob1Potencies <- potenciesOf ob1
+      ob6Potencies <- potenciesOf ob6
+      ob10Potencies <- potenciesOf ob10
+      pure { ob0: ob0Potencies, ob1: ob1Potencies, ob6: ob6Potencies, ob10: ob10Potencies }
 
-      FireWeakness {} -> Just { effectType: FilterFireWeakness, potencies: Nothing }
-      IceWeakness {} -> Just { effectType: FilterIceWeakness, potencies: Nothing }
-      LightningWeakness {} -> Just { effectType: FilterLightningWeakness, potencies: Nothing }
-      EarthWeakness {} -> Just { effectType: FilterEarthWeakness, potencies: Nothing }
-      WaterWeakness {} -> Just { effectType: FilterWaterWeakness, potencies: Nothing }
-      WindWeakness {} -> Just { effectType: FilterWindWeakness, potencies: Nothing }
+    effectTypeOf = case ob0 of
+      -- #(ref:heal-threshold)
+      Heal { percentage } -> if unwrap percentage >= 30 then Just FilterHeal else Nothing
+      Veil {} -> Just FilterVeil
+      Provoke {} -> Just FilterProvoke
+      Enfeeble {} -> Just FilterEnfeeble
+      Stop {} -> Just FilterStop
+      ExploitWeakness {} -> Just FilterExploitWeakness
+      Enliven {} -> Just FilterEnliven
+      HPGain {} -> Just FilterHPGain
 
-      PhysicalWeaponBoost {} -> Just { effectType: FilterPhysicalWeaponBoost, potencies: Nothing }
-      MagicWeaponBoost {} -> Just { effectType: FilterMagicWeaponBoost, potencies: Nothing }
-      PhysicalDamageBonus {} -> Just { effectType: FilterPhysicalDamageBonus, potencies: Nothing }
-      MagicDamageBonus {} -> Just { effectType: FilterMagicDamageBonus, potencies: Nothing }
+      FireWeakness {} -> Just FilterFireWeakness
+      IceWeakness {} -> Just FilterIceWeakness
+      LightningWeakness {} -> Just FilterLightningWeakness
+      EarthWeakness {} -> Just FilterEarthWeakness
+      WaterWeakness {} -> Just FilterWaterWeakness
+      WindWeakness {} -> Just FilterWindWeakness
 
-      FireWeaponBoost {} -> Just { effectType: FilterFireWeaponBoost, potencies: Nothing }
-      IceWeaponBoost {} -> Just { effectType: FilterIceWeaponBoost, potencies: Nothing }
-      LightningWeaponBoost {} -> Just { effectType: FilterLightningWeaponBoost, potencies: Nothing }
-      EarthWeaponBoost {} -> Just { effectType: FilterEarthWeaponBoost, potencies: Nothing }
-      WaterWeaponBoost {} -> Just { effectType: FilterWaterWeaponBoost, potencies: Nothing }
-      WindWeaponBoost {} -> Just { effectType: FilterWindWeaponBoost, potencies: Nothing }
+      PhysicalWeaponBoost {} -> Just FilterPhysicalWeaponBoost
+      MagicWeaponBoost {} -> Just FilterMagicWeaponBoost
+      PhysicalDamageBonus {} -> Just FilterPhysicalDamageBonus
+      MagicDamageBonus {} -> Just FilterMagicDamageBonus
 
-      FireDamageBonus {} -> Just { effectType: FilterFireDamageBonus, potencies: Nothing }
-      IceDamageBonus {} -> Just { effectType: FilterIceDamageBonus, potencies: Nothing }
-      LightningDamageBonus {} -> Just { effectType: FilterLightningDamageBonus, potencies: Nothing }
-      EarthDamageBonus {} -> Just { effectType: FilterEarthDamageBonus, potencies: Nothing }
-      WaterDamageBonus {} -> Just { effectType: FilterWaterDamageBonus, potencies: Nothing }
-      WindDamageBonus {} -> Just { effectType: FilterWindDamageBonus, potencies: Nothing }
+      FireWeaponBoost {} -> Just FilterFireWeaponBoost
+      IceWeaponBoost {} -> Just FilterIceWeaponBoost
+      LightningWeaponBoost {} -> Just FilterLightningWeaponBoost
+      EarthWeaponBoost {} -> Just FilterEarthWeaponBoost
+      WaterWeaponBoost {} -> Just FilterWaterWeaponBoost
+      WindWeaponBoost {} -> Just FilterWindWeaponBoost
 
-      PatkUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        PatkUp ob1, PatkUp ob6, PatkUp ob10 -> Just { effectType: FilterPatkUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      MatkUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        MatkUp ob1, MatkUp ob6, MatkUp ob10 -> Just { effectType: FilterMatkUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      PdefUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        PdefUp ob1, PdefUp ob6, PdefUp ob10 -> Just { effectType: FilterPdefUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      MdefUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        MdefUp ob1, MdefUp ob6, MdefUp ob10 -> Just { effectType: FilterMdefUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      FireDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        FireDamageUp ob1, FireDamageUp ob6, FireDamageUp ob10 -> Just { effectType: FilterFireDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      IceDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        IceDamageUp ob1, IceDamageUp ob6, IceDamageUp ob10 -> Just { effectType: FilterIceDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      LightningDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        LightningDamageUp ob1, LightningDamageUp ob6, LightningDamageUp ob10 -> Just { effectType: FilterLightningDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      EarthDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EarthDamageUp ob1, EarthDamageUp ob6, EarthDamageUp ob10 -> Just { effectType: FilterEarthDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      WaterDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WaterDamageUp ob1, WaterDamageUp ob6, WaterDamageUp ob10 -> Just { effectType: FilterWaterDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      WindDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WindDamageUp ob1, WindDamageUp ob6, WindDamageUp ob10 -> Just { effectType: FilterWindDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      FireResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        FireResistUp ob1, FireResistUp ob6, FireResistUp ob10 -> Just { effectType: FilterFireResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      IceResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        IceResistUp ob1, IceResistUp ob6, IceResistUp ob10 -> Just { effectType: FilterIceResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      LightningResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        LightningResistUp ob1, LightningResistUp ob6, LightningResistUp ob10 -> Just { effectType: FilterLightningResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      EarthResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EarthResistUp ob1, EarthResistUp ob6, EarthResistUp ob10 -> Just { effectType: FilterEarthResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      WaterResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WaterResistUp ob1, WaterResistUp ob6, WaterResistUp ob10 -> Just { effectType: FilterWaterResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      WindResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WindResistUp ob1, WindResistUp ob6, WindResistUp ob10 -> Just { effectType: FilterWindResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      EnhanceBuffs { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EnhanceBuffs ob1, EnhanceBuffs ob6, EnhanceBuffs ob10 -> Just { effectType: FilterEnhanceBuffs, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      PatkDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        PatkDown ob1, PatkDown ob6, PatkDown ob10 -> Just { effectType: FilterPatkDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      MatkDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        MatkDown ob1, MatkDown ob6, MatkDown ob10 -> Just { effectType: FilterMatkDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      PdefDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        PdefDown ob1, PdefDown ob6, PdefDown ob10 -> Just { effectType: FilterPdefDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      MdefDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        MdefDown ob1, MdefDown ob6, MdefDown ob10 -> Just { effectType: FilterMdefDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      FireDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        FireDamageDown ob1, FireDamageDown ob6, FireDamageDown ob10 -> Just { effectType: FilterFireDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      IceDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        IceDamageDown ob1, IceDamageDown ob6, IceDamageDown ob10 -> Just { effectType: FilterIceDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      LightningDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        LightningDamageDown ob1, LightningDamageDown ob6, LightningDamageDown ob10 -> Just { effectType: FilterLightningDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      EarthDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EarthDamageDown ob1, EarthDamageDown ob6, EarthDamageDown ob10 -> Just { effectType: FilterEarthDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      WaterDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WaterDamageDown ob1, WaterDamageDown ob6, WaterDamageDown ob10 -> Just { effectType: FilterWaterDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      WindDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WindDamageDown ob1, WindDamageDown ob6, WindDamageDown ob10 -> Just { effectType: FilterWindDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      FireResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        FireResistDown ob1, FireResistDown ob6, FireResistDown ob10 -> Just { effectType: FilterFireResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      IceResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        IceResistDown ob1, IceResistDown ob6, IceResistDown ob10 -> Just { effectType: FilterIceResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      LightningResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        LightningResistDown ob1, LightningResistDown ob6, LightningResistDown ob10 -> Just { effectType: FilterLightningResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      EarthResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EarthResistDown ob1, EarthResistDown ob6, EarthResistDown ob10 -> Just { effectType: FilterEarthResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      WaterResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WaterResistDown ob1, WaterResistDown ob6, WaterResistDown ob10 -> Just { effectType: FilterWaterResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      WindResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WindResistDown ob1, WindResistDown ob6, WindResistDown ob10 -> Just { effectType: FilterWindResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
-      EnhanceDebuffs { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EnhanceDebuffs ob1, EnhanceDebuffs ob6, EnhanceDebuffs ob10 -> Just { effectType: FilterEnhanceDebuffs, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
-        _, _, _ -> crash unit
+      FireDamageBonus {} -> Just FilterFireDamageBonus
+      IceDamageBonus {} -> Just FilterIceDamageBonus
+      LightningDamageBonus {} -> Just FilterLightningDamageBonus
+      EarthDamageBonus {} -> Just FilterEarthDamageBonus
+      WaterDamageBonus {} -> Just FilterWaterDamageBonus
+      WindDamageBonus {} -> Just FilterWindDamageBonus
 
-  crash _ = unsafeCrashWith $ "Effects for weapon " <> display weapon.name <> " are not in the same order"
+      PatkUp {} -> Just FilterPatkUp
+      MatkUp {} -> Just FilterMatkUp
+      PdefUp {} -> Just FilterPdefUp
+      MdefUp {} -> Just FilterMdefUp
+      FireDamageUp {} -> Just FilterFireDamageUp
+      IceDamageUp {} -> Just FilterIceDamageUp
+      LightningDamageUp {} -> Just FilterLightningDamageUp
+      EarthDamageUp {} -> Just FilterEarthDamageUp
+      WaterDamageUp {} -> Just FilterWaterDamageUp
+      WindDamageUp {} -> Just FilterWindDamageUp
+      FireResistUp {} -> Just FilterFireResistUp
+      IceResistUp {} -> Just FilterIceResistUp
+      LightningResistUp {} -> Just FilterLightningResistUp
+      EarthResistUp {} -> Just FilterEarthResistUp
+      WaterResistUp {} -> Just FilterWaterResistUp
+      WindResistUp {} -> Just FilterWindResistUp
+      EnhanceBuffs {} -> Just FilterEnhanceBuffs
+
+      PatkDown {} -> Just FilterPatkDown
+      MatkDown {} -> Just FilterMatkDown
+      PdefDown {} -> Just FilterPdefDown
+      MdefDown {} -> Just FilterMdefDown
+      FireDamageDown {} -> Just FilterFireDamageDown
+      IceDamageDown {} -> Just FilterIceDamageDown
+      LightningDamageDown {} -> Just FilterLightningDamageDown
+      EarthDamageDown {} -> Just FilterEarthDamageDown
+      WaterDamageDown {} -> Just FilterWaterDamageDown
+      WindDamageDown {} -> Just FilterWindDamageDown
+      FireResistDown {} -> Just FilterFireResistDown
+      IceResistDown {} -> Just FilterIceResistDown
+      LightningResistDown {} -> Just FilterLightningResistDown
+      EarthResistDown {} -> Just FilterEarthResistDown
+      WaterResistDown {} -> Just FilterWaterResistDown
+      WindResistDown {} -> Just FilterWindResistDown
+      EnhanceDebuffs {} -> Just FilterEnhanceDebuffs
 
 type ReadCacheResult =
   { userState :: UserState

--- a/src/Core/Database.purs
+++ b/src/Core/Database.purs
@@ -137,268 +137,14 @@ getDistinctObs weapon = do
   indices :: Int -> Array Int
   indices n = if n <= 0 then [] else Arr.range 0 (n - 1)
 
-  -- Two effects are equivalent if they have the same potencies and range
-  -- Duration, extension, and percentages are not considered.
+  -- Two effects are equivalent if they're the same kind of effect with the same
+  -- range and potencies. Duration, extension, and percentages are not considered.
+  -- Crashes if `x` and `y` are different kinds of effect: that would mean a weapon's
+  -- effects aren't listed in the same order at every overboost level.
   areWeaponEffectsEquivalent :: WeaponEffect -> WeaponEffect -> Boolean
-  areWeaponEffectsEquivalent x y =
-    case x of
-      Heal { range: range1, percentage: _ } ->
-        case y of
-          Heal { range: range2, percentage: _ } -> range1 == range2
-          _ -> crash unit
-      PatkUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          PatkUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      MatkUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          MatkUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      PdefUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          PdefUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      MdefUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          MdefUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      FireDamageUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          FireDamageUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      IceDamageUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          IceDamageUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      LightningDamageUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          LightningDamageUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      EarthDamageUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          EarthDamageUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      WaterDamageUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          WaterDamageUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      WindDamageUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          WindDamageUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      Veil { range: range1, durExt: _, percentage: _ } ->
-        case y of
-          Veil { range: range2, durExt: _, percentage: _ } -> range1 == range2
-          _ -> crash unit
-      Provoke { range: range1, durExt: _ } ->
-        case y of
-          Provoke { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      PatkDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          PatkDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      MatkDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          MatkDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      PdefDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          PdefDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      MdefDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          MdefDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      FireResistDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          FireResistDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      IceResistDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          IceResistDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      LightningResistDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          LightningResistDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      EarthResistDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          EarthResistDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      WaterResistDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          WaterResistDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      WindResistDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          WindResistDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      Enfeeble { range: range1, durExt: _ } ->
-        case y of
-          Enfeeble { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      Stop { range: range1, durExt: _ } ->
-        case y of
-          Stop { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      ExploitWeakness { range: range1, durExt: _, percentage: _ } ->
-        case y of
-          ExploitWeakness { range: range2, durExt: _, percentage: _ } -> range1 == range2
-          _ -> crash unit
-      HPGain { range: range1, durExt: _, percentage: _ } ->
-        case y of
-          HPGain { range: range2, durExt: _, percentage: _ } -> range1 == range2
-          _ -> crash unit
-      EnhanceBuffs { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          EnhanceBuffs { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      EnhanceDebuffs { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          EnhanceDebuffs { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      Enliven { range: range1, durExt: _ } ->
-        case y of
-          Enliven { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-
-      FireWeakness { range: range1, durExt: _ } ->
-        case y of
-          FireWeakness { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      IceWeakness { range: range1, durExt: _ } ->
-        case y of
-          IceWeakness { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      LightningWeakness { range: range1, durExt: _ } ->
-        case y of
-          LightningWeakness { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      EarthWeakness { range: range1, durExt: _ } ->
-        case y of
-          EarthWeakness { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      WaterWeakness { range: range1, durExt: _ } ->
-        case y of
-          WaterWeakness { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      WindWeakness { range: range1, durExt: _ } ->
-        case y of
-          WindWeakness { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      PhysicalWeaponBoost { range: range1, durExt: _ } ->
-        case y of
-          PhysicalWeaponBoost { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      MagicWeaponBoost { range: range1, durExt: _ } ->
-        case y of
-          MagicWeaponBoost { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      PhysicalDamageBonus { range: range1, durExt: _ } ->
-        case y of
-          PhysicalDamageBonus { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      MagicDamageBonus { range: range1, durExt: _ } ->
-        case y of
-          MagicDamageBonus { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      FireWeaponBoost { range: range1, durExt: _ } ->
-        case y of
-          FireWeaponBoost { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      IceWeaponBoost { range: range1, durExt: _ } ->
-        case y of
-          IceWeaponBoost { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      LightningWeaponBoost { range: range1, durExt: _ } ->
-        case y of
-          LightningWeaponBoost { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      EarthWeaponBoost { range: range1, durExt: _ } ->
-        case y of
-          EarthWeaponBoost { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      WaterWeaponBoost { range: range1, durExt: _ } ->
-        case y of
-          WaterWeaponBoost { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      WindWeaponBoost { range: range1, durExt: _ } ->
-        case y of
-          WindWeaponBoost { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      FireDamageBonus { range: range1, durExt: _ } ->
-        case y of
-          FireDamageBonus { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      IceDamageBonus { range: range1, durExt: _ } ->
-        case y of
-          IceDamageBonus { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      LightningDamageBonus { range: range1, durExt: _ } ->
-        case y of
-          LightningDamageBonus { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      EarthDamageBonus { range: range1, durExt: _ } ->
-        case y of
-          EarthDamageBonus { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      WaterDamageBonus { range: range1, durExt: _ } ->
-        case y of
-          WaterDamageBonus { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      WindDamageBonus { range: range1, durExt: _ } ->
-        case y of
-          WindDamageBonus { range: range2, durExt: _ } -> range1 == range2
-          _ -> crash unit
-      FireDamageDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          FireDamageDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      IceDamageDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          IceDamageDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      LightningDamageDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          LightningDamageDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      EarthDamageDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          EarthDamageDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      WaterDamageDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          WaterDamageDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      WindDamageDown { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          WindDamageDown { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      FireResistUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          FireResistUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      IceResistUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          IceResistUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      LightningResistUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          LightningResistUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      EarthResistUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          EarthResistUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      WaterResistUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          WaterResistUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
-      WindResistUp { range: range1, durExt: _, potencies: pot1 } ->
-        case y of
-          WindResistUp { range: range2, durExt: _, potencies: pot2 } -> pot1 == pot2 && range1 == range2
-          _ -> crash unit
+  areWeaponEffectsEquivalent x y
+    | tagOf x /= tagOf y = crash unit
+    | otherwise = rangeOf x == rangeOf y && potenciesOf x == potenciesOf y
 
   crash _ = unsafeCrashWith $ "Effects for weapon " <> display weapon.name <> " are not in the same order"
 
@@ -656,6 +402,75 @@ potenciesOf = case _ of
   EnhanceDebuffs r -> Just r.potencies
   Enliven _ -> Nothing
 
+-- A tag identifying which kind of effect this is (i.e. its constructor), so two
+-- effects can be checked for "same kind" regardless of their range or potencies.
+tagOf :: WeaponEffect -> FilterEffectType
+tagOf = case _ of
+  Heal _ -> FilterHeal
+  PatkUp _ -> FilterPatkUp
+  MatkUp _ -> FilterMatkUp
+  PdefUp _ -> FilterPdefUp
+  MdefUp _ -> FilterMdefUp
+  HPGain _ -> FilterHPGain
+  EnhanceBuffs _ -> FilterEnhanceBuffs
+  PhysicalWeaponBoost _ -> FilterPhysicalWeaponBoost
+  MagicWeaponBoost _ -> FilterMagicWeaponBoost
+  PhysicalDamageBonus _ -> FilterPhysicalDamageBonus
+  MagicDamageBonus _ -> FilterMagicDamageBonus
+  FireDamageUp _ -> FilterFireDamageUp
+  IceDamageUp _ -> FilterIceDamageUp
+  LightningDamageUp _ -> FilterLightningDamageUp
+  EarthDamageUp _ -> FilterEarthDamageUp
+  WaterDamageUp _ -> FilterWaterDamageUp
+  WindDamageUp _ -> FilterWindDamageUp
+  FireWeaponBoost _ -> FilterFireWeaponBoost
+  IceWeaponBoost _ -> FilterIceWeaponBoost
+  LightningWeaponBoost _ -> FilterLightningWeaponBoost
+  EarthWeaponBoost _ -> FilterEarthWeaponBoost
+  WaterWeaponBoost _ -> FilterWaterWeaponBoost
+  WindWeaponBoost _ -> FilterWindWeaponBoost
+  FireDamageBonus _ -> FilterFireDamageBonus
+  IceDamageBonus _ -> FilterIceDamageBonus
+  LightningDamageBonus _ -> FilterLightningDamageBonus
+  EarthDamageBonus _ -> FilterEarthDamageBonus
+  WaterDamageBonus _ -> FilterWaterDamageBonus
+  WindDamageBonus _ -> FilterWindDamageBonus
+  FireResistUp _ -> FilterFireResistUp
+  IceResistUp _ -> FilterIceResistUp
+  LightningResistUp _ -> FilterLightningResistUp
+  EarthResistUp _ -> FilterEarthResistUp
+  WaterResistUp _ -> FilterWaterResistUp
+  WindResistUp _ -> FilterWindResistUp
+  Veil _ -> FilterVeil
+  Provoke _ -> FilterProvoke
+  PatkDown _ -> FilterPatkDown
+  MatkDown _ -> FilterMatkDown
+  PdefDown _ -> FilterPdefDown
+  MdefDown _ -> FilterMdefDown
+  FireDamageDown _ -> FilterFireDamageDown
+  IceDamageDown _ -> FilterIceDamageDown
+  LightningDamageDown _ -> FilterLightningDamageDown
+  EarthDamageDown _ -> FilterEarthDamageDown
+  WaterDamageDown _ -> FilterWaterDamageDown
+  WindDamageDown _ -> FilterWindDamageDown
+  FireResistDown _ -> FilterFireResistDown
+  IceResistDown _ -> FilterIceResistDown
+  LightningResistDown _ -> FilterLightningResistDown
+  EarthResistDown _ -> FilterEarthResistDown
+  WaterResistDown _ -> FilterWaterResistDown
+  WindResistDown _ -> FilterWindResistDown
+  FireWeakness _ -> FilterFireWeakness
+  IceWeakness _ -> FilterIceWeakness
+  LightningWeakness _ -> FilterLightningWeakness
+  EarthWeakness _ -> FilterEarthWeakness
+  WaterWeakness _ -> FilterWaterWeakness
+  WindWeakness _ -> FilterWindWeakness
+  Enfeeble _ -> FilterEnfeeble
+  Stop _ -> FilterStop
+  ExploitWeakness _ -> FilterExploitWeakness
+  EnhanceDebuffs _ -> FilterEnhanceDebuffs
+  Enliven _ -> FilterEnliven
+
 groupsForWeapon :: Weapon -> List.List GroupEntry
 groupsForWeapon weapon = do
   mergeRanges $ Arr.fold
@@ -802,75 +617,7 @@ groupsForWeapon weapon = do
     effectTypeOf = case ob0 of
       -- #(ref:heal-threshold)
       Heal { percentage } -> if unwrap percentage >= 30 then Just FilterHeal else Nothing
-      Veil {} -> Just FilterVeil
-      Provoke {} -> Just FilterProvoke
-      Enfeeble {} -> Just FilterEnfeeble
-      Stop {} -> Just FilterStop
-      ExploitWeakness {} -> Just FilterExploitWeakness
-      Enliven {} -> Just FilterEnliven
-      HPGain {} -> Just FilterHPGain
-
-      FireWeakness {} -> Just FilterFireWeakness
-      IceWeakness {} -> Just FilterIceWeakness
-      LightningWeakness {} -> Just FilterLightningWeakness
-      EarthWeakness {} -> Just FilterEarthWeakness
-      WaterWeakness {} -> Just FilterWaterWeakness
-      WindWeakness {} -> Just FilterWindWeakness
-
-      PhysicalWeaponBoost {} -> Just FilterPhysicalWeaponBoost
-      MagicWeaponBoost {} -> Just FilterMagicWeaponBoost
-      PhysicalDamageBonus {} -> Just FilterPhysicalDamageBonus
-      MagicDamageBonus {} -> Just FilterMagicDamageBonus
-
-      FireWeaponBoost {} -> Just FilterFireWeaponBoost
-      IceWeaponBoost {} -> Just FilterIceWeaponBoost
-      LightningWeaponBoost {} -> Just FilterLightningWeaponBoost
-      EarthWeaponBoost {} -> Just FilterEarthWeaponBoost
-      WaterWeaponBoost {} -> Just FilterWaterWeaponBoost
-      WindWeaponBoost {} -> Just FilterWindWeaponBoost
-
-      FireDamageBonus {} -> Just FilterFireDamageBonus
-      IceDamageBonus {} -> Just FilterIceDamageBonus
-      LightningDamageBonus {} -> Just FilterLightningDamageBonus
-      EarthDamageBonus {} -> Just FilterEarthDamageBonus
-      WaterDamageBonus {} -> Just FilterWaterDamageBonus
-      WindDamageBonus {} -> Just FilterWindDamageBonus
-
-      PatkUp {} -> Just FilterPatkUp
-      MatkUp {} -> Just FilterMatkUp
-      PdefUp {} -> Just FilterPdefUp
-      MdefUp {} -> Just FilterMdefUp
-      FireDamageUp {} -> Just FilterFireDamageUp
-      IceDamageUp {} -> Just FilterIceDamageUp
-      LightningDamageUp {} -> Just FilterLightningDamageUp
-      EarthDamageUp {} -> Just FilterEarthDamageUp
-      WaterDamageUp {} -> Just FilterWaterDamageUp
-      WindDamageUp {} -> Just FilterWindDamageUp
-      FireResistUp {} -> Just FilterFireResistUp
-      IceResistUp {} -> Just FilterIceResistUp
-      LightningResistUp {} -> Just FilterLightningResistUp
-      EarthResistUp {} -> Just FilterEarthResistUp
-      WaterResistUp {} -> Just FilterWaterResistUp
-      WindResistUp {} -> Just FilterWindResistUp
-      EnhanceBuffs {} -> Just FilterEnhanceBuffs
-
-      PatkDown {} -> Just FilterPatkDown
-      MatkDown {} -> Just FilterMatkDown
-      PdefDown {} -> Just FilterPdefDown
-      MdefDown {} -> Just FilterMdefDown
-      FireDamageDown {} -> Just FilterFireDamageDown
-      IceDamageDown {} -> Just FilterIceDamageDown
-      LightningDamageDown {} -> Just FilterLightningDamageDown
-      EarthDamageDown {} -> Just FilterEarthDamageDown
-      WaterDamageDown {} -> Just FilterWaterDamageDown
-      WindDamageDown {} -> Just FilterWindDamageDown
-      FireResistDown {} -> Just FilterFireResistDown
-      IceResistDown {} -> Just FilterIceResistDown
-      LightningResistDown {} -> Just FilterLightningResistDown
-      EarthResistDown {} -> Just FilterEarthResistDown
-      WaterResistDown {} -> Just FilterWaterResistDown
-      WindResistDown {} -> Just FilterWindResistDown
-      EnhanceDebuffs {} -> Just FilterEnhanceDebuffs
+      _ -> Just (tagOf ob0)
 
 type ReadCacheResult =
   { userState :: UserState

--- a/src/Core/Database.purs
+++ b/src/Core/Database.purs
@@ -517,6 +517,75 @@ type GroupEntry =
   , groupedWeapon :: GroupedWeapon
   }
 
+-- The range of an effect. Every `WeaponEffect` constructor carries a `range` field;
+-- this extracts it without caring which constructor it is.
+rangeOf :: WeaponEffect -> Range
+rangeOf = case _ of
+  Heal r -> r.range
+  PatkUp r -> r.range
+  MatkUp r -> r.range
+  PdefUp r -> r.range
+  MdefUp r -> r.range
+  HPGain r -> r.range
+  EnhanceBuffs r -> r.range
+  PhysicalWeaponBoost r -> r.range
+  MagicWeaponBoost r -> r.range
+  PhysicalDamageBonus r -> r.range
+  MagicDamageBonus r -> r.range
+  FireDamageUp r -> r.range
+  IceDamageUp r -> r.range
+  LightningDamageUp r -> r.range
+  EarthDamageUp r -> r.range
+  WaterDamageUp r -> r.range
+  WindDamageUp r -> r.range
+  FireWeaponBoost r -> r.range
+  IceWeaponBoost r -> r.range
+  LightningWeaponBoost r -> r.range
+  EarthWeaponBoost r -> r.range
+  WaterWeaponBoost r -> r.range
+  WindWeaponBoost r -> r.range
+  FireDamageBonus r -> r.range
+  IceDamageBonus r -> r.range
+  LightningDamageBonus r -> r.range
+  EarthDamageBonus r -> r.range
+  WaterDamageBonus r -> r.range
+  WindDamageBonus r -> r.range
+  FireResistUp r -> r.range
+  IceResistUp r -> r.range
+  LightningResistUp r -> r.range
+  EarthResistUp r -> r.range
+  WaterResistUp r -> r.range
+  WindResistUp r -> r.range
+  Veil r -> r.range
+  Provoke r -> r.range
+  PatkDown r -> r.range
+  MatkDown r -> r.range
+  PdefDown r -> r.range
+  MdefDown r -> r.range
+  FireDamageDown r -> r.range
+  IceDamageDown r -> r.range
+  LightningDamageDown r -> r.range
+  EarthDamageDown r -> r.range
+  WaterDamageDown r -> r.range
+  WindDamageDown r -> r.range
+  FireResistDown r -> r.range
+  IceResistDown r -> r.range
+  LightningResistDown r -> r.range
+  EarthResistDown r -> r.range
+  WaterResistDown r -> r.range
+  WindResistDown r -> r.range
+  FireWeakness r -> r.range
+  IceWeakness r -> r.range
+  LightningWeakness r -> r.range
+  EarthWeakness r -> r.range
+  WaterWeakness r -> r.range
+  WindWeakness r -> r.range
+  Enfeeble r -> r.range
+  Stop r -> r.range
+  ExploitWeakness r -> r.range
+  EnhanceDebuffs r -> r.range
+  Enliven r -> r.range
+
 groupsForWeapon :: Weapon -> List.List GroupEntry
 groupsForWeapon weapon = do
   mergeRanges $ Arr.fold
@@ -526,6 +595,7 @@ groupsForWeapon weapon = do
     , getSigilBoost
     ]
   where
+  -- Check if the weapon has a Cure All S-Ability.
   -- #(ref:use-cure-spell)
   getCureAllAbility :: LazyList.List GroupEntry
   getCureAllAbility = do
@@ -536,7 +606,7 @@ groupsForWeapon weapon = do
         , groupedWeapon:
             { weaponName: weapon.name
             , ranges: Just
-                [ { range: All
+                [ { allRanges: { ob0: All, ob1: All, ob6: All, ob10: All }
                   , allPotencies: Nothing
                   }
                 ]
@@ -545,6 +615,7 @@ groupsForWeapon weapon = do
     else
       LazyList.nil
 
+  -- Check if the weapon has a C. Ability Diamond Sigil.
   getCommandAbilityDiamondSigil :: LazyList.List GroupEntry
   getCommandAbilityDiamondSigil =
     case weapon.commandAbilitySigil of
@@ -557,6 +628,7 @@ groupsForWeapon weapon = do
         }
       _ -> LazyList.nil
 
+  -- Check if the weapon has a Sigil Boost S. Ability.
   -- #(ref:use-sigil-boosts)
   getSigilBoost :: LazyList.List GroupEntry
   getSigilBoost =
@@ -584,27 +656,20 @@ groupsForWeapon weapon = do
     ob6 <- ZipList $ LazyList.fromFoldable weapon.ob6.effects
     ob10 <- ZipList $ LazyList.fromFoldable weapon.ob10.effects
     in
-      groupForWeaponEffect ob0 ob1 ob6 ob10 <#> \{ effectType, potencies, range } -> do
-        let
-          ranges =
-            case range of
-              Just range ->
-                Just
-                  [ { range
-                    , allPotencies: potencies
-                    }
-                  ]
-              Nothing -> Nothing
-
+      groupForWeaponEffect ob0 ob1 ob6 ob10 <#> \{ effectType, potencies, allRanges } ->
         { effectType
         , groupedWeapon:
             { weaponName: weapon.name
-            , ranges
+            , ranges: Just
+                [ { allRanges
+                  , allPotencies: potencies
+                  }
+                ]
             }
         }
 
   -- If there are many ranges for the same effect (e.g. Arctic Star has PATK Up SingleTarget & PATK Up Self),
-  -- this function will merge those `GroupEntry`s into a single one.
+  -- this function will merge those `GroupEntry`s (with one `GroupedWeaponRange` each) into a single one (with many `GroupedWeaponRange`s).
   mergeRanges :: LazyList.List GroupEntry -> List.List GroupEntry
   mergeRanges groupEntries = do
     let
@@ -631,8 +696,6 @@ groupsForWeapon weapon = do
           groupEntries
     Map.values merged
 
-  -- INVARIANT: this function assumes an effect has the same range at all overboost levels,
-  -- so it just returns the range for the effect at OB0.
   groupForWeaponEffect
     :: WeaponEffect
     -> WeaponEffect
@@ -641,10 +704,20 @@ groupsForWeapon weapon = do
     -> Maybe
          { effectType :: FilterEffectType
          , potencies :: Maybe AllPotencies
-         , range :: Maybe Range
+         , allRanges :: AllRanges
          }
-  groupForWeaponEffect ob0 ob1 ob6 ob10 = do
-    case ob0 of
+  -- NOTE: an effect can have a different range at each overboost level
+  -- (e.g. Festive Sword's Enliven is `Self` at OB0/OB1 and `All` at OB6/OB10),
+  -- so we record the range at every level via `rangeOf`.
+  -- The `effectType`/`potencies` are still determined from the OB0 effect.
+  groupForWeaponEffect ob0 ob1 ob6 ob10 =
+    inner <#> \{ effectType, potencies } ->
+      { effectType
+      , potencies
+      , allRanges: { ob0: rangeOf ob0, ob1: rangeOf ob1, ob6: rangeOf ob6, ob10: rangeOf ob10 }
+      }
+    where
+    inner = case ob0 of
       Heal { range, percentage } ->
         if unwrap percentage >= 30 then Just { effectType: FilterHeal, range: Just range, potencies: Nothing }
         else Nothing

--- a/src/Core/Database.purs
+++ b/src/Core/Database.purs
@@ -718,144 +718,144 @@ groupsForWeapon weapon = do
       }
     where
     inner = case ob0 of
-      Heal { range, percentage } ->
-        if unwrap percentage >= 30 then Just { effectType: FilterHeal, range: Just range, potencies: Nothing }
+      Heal { percentage } ->
+        if unwrap percentage >= 30 then Just { effectType: FilterHeal, potencies: Nothing }
         else Nothing
-      Veil { range } -> Just { effectType: FilterVeil, range: Just range, potencies: Nothing }
-      Provoke { range } -> Just { effectType: FilterProvoke, range: Just range, potencies: Nothing }
-      Enfeeble { range } -> Just { effectType: FilterEnfeeble, range: Just range, potencies: Nothing }
-      Stop { range } -> Just { effectType: FilterStop, range: Just range, potencies: Nothing }
-      ExploitWeakness { range } -> Just { effectType: FilterExploitWeakness, range: Just range, potencies: Nothing }
-      Enliven { range } -> Just { effectType: FilterEnliven, range: Just range, potencies: Nothing }
-      HPGain { range } -> Just { effectType: FilterHPGain, range: Just range, potencies: Nothing }
+      Veil {} -> Just { effectType: FilterVeil, potencies: Nothing }
+      Provoke {} -> Just { effectType: FilterProvoke, potencies: Nothing }
+      Enfeeble {} -> Just { effectType: FilterEnfeeble, potencies: Nothing }
+      Stop {} -> Just { effectType: FilterStop, potencies: Nothing }
+      ExploitWeakness {} -> Just { effectType: FilterExploitWeakness, potencies: Nothing }
+      Enliven {} -> Just { effectType: FilterEnliven, potencies: Nothing }
+      HPGain {} -> Just { effectType: FilterHPGain, potencies: Nothing }
 
-      FireWeakness { range } -> Just { effectType: FilterFireWeakness, range: Just range, potencies: Nothing }
-      IceWeakness { range } -> Just { effectType: FilterIceWeakness, range: Just range, potencies: Nothing }
-      LightningWeakness { range } -> Just { effectType: FilterLightningWeakness, range: Just range, potencies: Nothing }
-      EarthWeakness { range } -> Just { effectType: FilterEarthWeakness, range: Just range, potencies: Nothing }
-      WaterWeakness { range } -> Just { effectType: FilterWaterWeakness, range: Just range, potencies: Nothing }
-      WindWeakness { range } -> Just { effectType: FilterWindWeakness, range: Just range, potencies: Nothing }
+      FireWeakness {} -> Just { effectType: FilterFireWeakness, potencies: Nothing }
+      IceWeakness {} -> Just { effectType: FilterIceWeakness, potencies: Nothing }
+      LightningWeakness {} -> Just { effectType: FilterLightningWeakness, potencies: Nothing }
+      EarthWeakness {} -> Just { effectType: FilterEarthWeakness, potencies: Nothing }
+      WaterWeakness {} -> Just { effectType: FilterWaterWeakness, potencies: Nothing }
+      WindWeakness {} -> Just { effectType: FilterWindWeakness, potencies: Nothing }
 
-      PhysicalWeaponBoost { range } -> Just { effectType: FilterPhysicalWeaponBoost, range: Just range, potencies: Nothing }
-      MagicWeaponBoost { range } -> Just { effectType: FilterMagicWeaponBoost, range: Just range, potencies: Nothing }
-      PhysicalDamageBonus { range } -> Just { effectType: FilterPhysicalDamageBonus, range: Just range, potencies: Nothing }
-      MagicDamageBonus { range } -> Just { effectType: FilterMagicDamageBonus, range: Just range, potencies: Nothing }
+      PhysicalWeaponBoost {} -> Just { effectType: FilterPhysicalWeaponBoost, potencies: Nothing }
+      MagicWeaponBoost {} -> Just { effectType: FilterMagicWeaponBoost, potencies: Nothing }
+      PhysicalDamageBonus {} -> Just { effectType: FilterPhysicalDamageBonus, potencies: Nothing }
+      MagicDamageBonus {} -> Just { effectType: FilterMagicDamageBonus, potencies: Nothing }
 
-      FireWeaponBoost { range } -> Just { effectType: FilterFireWeaponBoost, range: Just range, potencies: Nothing }
-      IceWeaponBoost { range } -> Just { effectType: FilterIceWeaponBoost, range: Just range, potencies: Nothing }
-      LightningWeaponBoost { range } -> Just { effectType: FilterLightningWeaponBoost, range: Just range, potencies: Nothing }
-      EarthWeaponBoost { range } -> Just { effectType: FilterEarthWeaponBoost, range: Just range, potencies: Nothing }
-      WaterWeaponBoost { range } -> Just { effectType: FilterWaterWeaponBoost, range: Just range, potencies: Nothing }
-      WindWeaponBoost { range } -> Just { effectType: FilterWindWeaponBoost, range: Just range, potencies: Nothing }
+      FireWeaponBoost {} -> Just { effectType: FilterFireWeaponBoost, potencies: Nothing }
+      IceWeaponBoost {} -> Just { effectType: FilterIceWeaponBoost, potencies: Nothing }
+      LightningWeaponBoost {} -> Just { effectType: FilterLightningWeaponBoost, potencies: Nothing }
+      EarthWeaponBoost {} -> Just { effectType: FilterEarthWeaponBoost, potencies: Nothing }
+      WaterWeaponBoost {} -> Just { effectType: FilterWaterWeaponBoost, potencies: Nothing }
+      WindWeaponBoost {} -> Just { effectType: FilterWindWeaponBoost, potencies: Nothing }
 
-      FireDamageBonus { range } -> Just { effectType: FilterFireDamageBonus, range: Just range, potencies: Nothing }
-      IceDamageBonus { range } -> Just { effectType: FilterIceDamageBonus, range: Just range, potencies: Nothing }
-      LightningDamageBonus { range } -> Just { effectType: FilterLightningDamageBonus, range: Just range, potencies: Nothing }
-      EarthDamageBonus { range } -> Just { effectType: FilterEarthDamageBonus, range: Just range, potencies: Nothing }
-      WaterDamageBonus { range } -> Just { effectType: FilterWaterDamageBonus, range: Just range, potencies: Nothing }
-      WindDamageBonus { range } -> Just { effectType: FilterWindDamageBonus, range: Just range, potencies: Nothing }
+      FireDamageBonus {} -> Just { effectType: FilterFireDamageBonus, potencies: Nothing }
+      IceDamageBonus {} -> Just { effectType: FilterIceDamageBonus, potencies: Nothing }
+      LightningDamageBonus {} -> Just { effectType: FilterLightningDamageBonus, potencies: Nothing }
+      EarthDamageBonus {} -> Just { effectType: FilterEarthDamageBonus, potencies: Nothing }
+      WaterDamageBonus {} -> Just { effectType: FilterWaterDamageBonus, potencies: Nothing }
+      WindDamageBonus {} -> Just { effectType: FilterWindDamageBonus, potencies: Nothing }
 
-      PatkUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        PatkUp ob1, PatkUp ob6, PatkUp ob10 -> Just { effectType: FilterPatkUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      PatkUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        PatkUp ob1, PatkUp ob6, PatkUp ob10 -> Just { effectType: FilterPatkUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      MatkUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        MatkUp ob1, MatkUp ob6, MatkUp ob10 -> Just { effectType: FilterMatkUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      MatkUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        MatkUp ob1, MatkUp ob6, MatkUp ob10 -> Just { effectType: FilterMatkUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      PdefUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        PdefUp ob1, PdefUp ob6, PdefUp ob10 -> Just { effectType: FilterPdefUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      PdefUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        PdefUp ob1, PdefUp ob6, PdefUp ob10 -> Just { effectType: FilterPdefUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      MdefUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        MdefUp ob1, MdefUp ob6, MdefUp ob10 -> Just { effectType: FilterMdefUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      MdefUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        MdefUp ob1, MdefUp ob6, MdefUp ob10 -> Just { effectType: FilterMdefUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      FireDamageUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        FireDamageUp ob1, FireDamageUp ob6, FireDamageUp ob10 -> Just { effectType: FilterFireDamageUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      FireDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        FireDamageUp ob1, FireDamageUp ob6, FireDamageUp ob10 -> Just { effectType: FilterFireDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      IceDamageUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        IceDamageUp ob1, IceDamageUp ob6, IceDamageUp ob10 -> Just { effectType: FilterIceDamageUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      IceDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        IceDamageUp ob1, IceDamageUp ob6, IceDamageUp ob10 -> Just { effectType: FilterIceDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      LightningDamageUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        LightningDamageUp ob1, LightningDamageUp ob6, LightningDamageUp ob10 -> Just { effectType: FilterLightningDamageUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      LightningDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        LightningDamageUp ob1, LightningDamageUp ob6, LightningDamageUp ob10 -> Just { effectType: FilterLightningDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      EarthDamageUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EarthDamageUp ob1, EarthDamageUp ob6, EarthDamageUp ob10 -> Just { effectType: FilterEarthDamageUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      EarthDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        EarthDamageUp ob1, EarthDamageUp ob6, EarthDamageUp ob10 -> Just { effectType: FilterEarthDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      WaterDamageUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WaterDamageUp ob1, WaterDamageUp ob6, WaterDamageUp ob10 -> Just { effectType: FilterWaterDamageUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      WaterDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        WaterDamageUp ob1, WaterDamageUp ob6, WaterDamageUp ob10 -> Just { effectType: FilterWaterDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      WindDamageUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WindDamageUp ob1, WindDamageUp ob6, WindDamageUp ob10 -> Just { effectType: FilterWindDamageUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      WindDamageUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        WindDamageUp ob1, WindDamageUp ob6, WindDamageUp ob10 -> Just { effectType: FilterWindDamageUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      FireResistUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        FireResistUp ob1, FireResistUp ob6, FireResistUp ob10 -> Just { effectType: FilterFireResistUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      FireResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        FireResistUp ob1, FireResistUp ob6, FireResistUp ob10 -> Just { effectType: FilterFireResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      IceResistUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        IceResistUp ob1, IceResistUp ob6, IceResistUp ob10 -> Just { effectType: FilterIceResistUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      IceResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        IceResistUp ob1, IceResistUp ob6, IceResistUp ob10 -> Just { effectType: FilterIceResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      LightningResistUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        LightningResistUp ob1, LightningResistUp ob6, LightningResistUp ob10 -> Just { effectType: FilterLightningResistUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      LightningResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        LightningResistUp ob1, LightningResistUp ob6, LightningResistUp ob10 -> Just { effectType: FilterLightningResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      EarthResistUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EarthResistUp ob1, EarthResistUp ob6, EarthResistUp ob10 -> Just { effectType: FilterEarthResistUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      EarthResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        EarthResistUp ob1, EarthResistUp ob6, EarthResistUp ob10 -> Just { effectType: FilterEarthResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      WaterResistUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WaterResistUp ob1, WaterResistUp ob6, WaterResistUp ob10 -> Just { effectType: FilterWaterResistUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      WaterResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        WaterResistUp ob1, WaterResistUp ob6, WaterResistUp ob10 -> Just { effectType: FilterWaterResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      WindResistUp { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WindResistUp ob1, WindResistUp ob6, WindResistUp ob10 -> Just { effectType: FilterWindResistUp, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      WindResistUp { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        WindResistUp ob1, WindResistUp ob6, WindResistUp ob10 -> Just { effectType: FilterWindResistUp, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      EnhanceBuffs { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EnhanceBuffs ob1, EnhanceBuffs ob6, EnhanceBuffs ob10 -> Just { effectType: FilterEnhanceBuffs, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      EnhanceBuffs { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        EnhanceBuffs ob1, EnhanceBuffs ob6, EnhanceBuffs ob10 -> Just { effectType: FilterEnhanceBuffs, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      PatkDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        PatkDown ob1, PatkDown ob6, PatkDown ob10 -> Just { effectType: FilterPatkDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      PatkDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        PatkDown ob1, PatkDown ob6, PatkDown ob10 -> Just { effectType: FilterPatkDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      MatkDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        MatkDown ob1, MatkDown ob6, MatkDown ob10 -> Just { effectType: FilterMatkDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      MatkDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        MatkDown ob1, MatkDown ob6, MatkDown ob10 -> Just { effectType: FilterMatkDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      PdefDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        PdefDown ob1, PdefDown ob6, PdefDown ob10 -> Just { effectType: FilterPdefDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      PdefDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        PdefDown ob1, PdefDown ob6, PdefDown ob10 -> Just { effectType: FilterPdefDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      MdefDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        MdefDown ob1, MdefDown ob6, MdefDown ob10 -> Just { effectType: FilterMdefDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      MdefDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        MdefDown ob1, MdefDown ob6, MdefDown ob10 -> Just { effectType: FilterMdefDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      FireDamageDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        FireDamageDown ob1, FireDamageDown ob6, FireDamageDown ob10 -> Just { effectType: FilterFireDamageDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      FireDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        FireDamageDown ob1, FireDamageDown ob6, FireDamageDown ob10 -> Just { effectType: FilterFireDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      IceDamageDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        IceDamageDown ob1, IceDamageDown ob6, IceDamageDown ob10 -> Just { effectType: FilterIceDamageDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      IceDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        IceDamageDown ob1, IceDamageDown ob6, IceDamageDown ob10 -> Just { effectType: FilterIceDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      LightningDamageDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        LightningDamageDown ob1, LightningDamageDown ob6, LightningDamageDown ob10 -> Just { effectType: FilterLightningDamageDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      LightningDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        LightningDamageDown ob1, LightningDamageDown ob6, LightningDamageDown ob10 -> Just { effectType: FilterLightningDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      EarthDamageDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EarthDamageDown ob1, EarthDamageDown ob6, EarthDamageDown ob10 -> Just { effectType: FilterEarthDamageDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      EarthDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        EarthDamageDown ob1, EarthDamageDown ob6, EarthDamageDown ob10 -> Just { effectType: FilterEarthDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      WaterDamageDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WaterDamageDown ob1, WaterDamageDown ob6, WaterDamageDown ob10 -> Just { effectType: FilterWaterDamageDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      WaterDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        WaterDamageDown ob1, WaterDamageDown ob6, WaterDamageDown ob10 -> Just { effectType: FilterWaterDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      WindDamageDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WindDamageDown ob1, WindDamageDown ob6, WindDamageDown ob10 -> Just { effectType: FilterWindDamageDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      WindDamageDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        WindDamageDown ob1, WindDamageDown ob6, WindDamageDown ob10 -> Just { effectType: FilterWindDamageDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      FireResistDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        FireResistDown ob1, FireResistDown ob6, FireResistDown ob10 -> Just { effectType: FilterFireResistDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      FireResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        FireResistDown ob1, FireResistDown ob6, FireResistDown ob10 -> Just { effectType: FilterFireResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      IceResistDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        IceResistDown ob1, IceResistDown ob6, IceResistDown ob10 -> Just { effectType: FilterIceResistDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      IceResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        IceResistDown ob1, IceResistDown ob6, IceResistDown ob10 -> Just { effectType: FilterIceResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      LightningResistDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        LightningResistDown ob1, LightningResistDown ob6, LightningResistDown ob10 -> Just { effectType: FilterLightningResistDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      LightningResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        LightningResistDown ob1, LightningResistDown ob6, LightningResistDown ob10 -> Just { effectType: FilterLightningResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      EarthResistDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EarthResistDown ob1, EarthResistDown ob6, EarthResistDown ob10 -> Just { effectType: FilterEarthResistDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      EarthResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        EarthResistDown ob1, EarthResistDown ob6, EarthResistDown ob10 -> Just { effectType: FilterEarthResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      WaterResistDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WaterResistDown ob1, WaterResistDown ob6, WaterResistDown ob10 -> Just { effectType: FilterWaterResistDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      WaterResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        WaterResistDown ob1, WaterResistDown ob6, WaterResistDown ob10 -> Just { effectType: FilterWaterResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      WindResistDown { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        WindResistDown ob1, WindResistDown ob6, WindResistDown ob10 -> Just { effectType: FilterWindResistDown, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      WindResistDown { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        WindResistDown ob1, WindResistDown ob6, WindResistDown ob10 -> Just { effectType: FilterWindResistDown, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
-      EnhanceDebuffs { range, potencies: ob0Potencies } -> case ob1, ob6, ob10 of
-        EnhanceDebuffs ob1, EnhanceDebuffs ob6, EnhanceDebuffs ob10 -> Just { effectType: FilterEnhanceDebuffs, range: Just range, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
+      EnhanceDebuffs { potencies: ob0Potencies } -> case ob1, ob6, ob10 of
+        EnhanceDebuffs ob1, EnhanceDebuffs ob6, EnhanceDebuffs ob10 -> Just { effectType: FilterEnhanceDebuffs, potencies: Just { ob0: ob0Potencies, ob1: ob1.potencies, ob6: ob6.potencies, ob10: ob10.potencies } }
         _, _, _ -> crash unit
 
   crash _ = unsafeCrashWith $ "Effects for weapon " <> display weapon.name <> " are not in the same order"

--- a/src/Core/Database/Types.purs
+++ b/src/Core/Database/Types.purs
@@ -107,9 +107,19 @@ type GroupedWeapon =
   }
 
 type GroupedWeaponRange =
-  { range :: Range
+  -- The range an effect has at each overboost level.
+  -- Most effects have the same range at all levels, but some don't:
+  -- e.g. Festive Sword's Enliven is `Self` at OB0/OB1 and `All` at OB6/OB10.
+  { allRanges :: AllRanges
   -- This will be `None` for effects that don't have potencies (e.g. `Heal`)
   , allPotencies :: Maybe AllPotencies
+  }
+
+type AllRanges =
+  { ob0 :: Range
+  , ob1 :: Range
+  , ob6 :: Range
+  , ob10 :: Range
   }
 
 type AllPotencies =

--- a/src/Core/Weapons/Search.purs
+++ b/src/Core/Weapons/Search.purs
@@ -104,7 +104,7 @@ findMatchingWeapons filter dbState = do
                 -- The effect has associated ranges.
                 -- We either fail if they don't match the range specified by the user,
                 -- or succeed with a nonempty array.
-                matchingRanges <- matchRanges filter.range ranges
+                matchingRanges <- matchRanges weaponState.ownedOb filter.range ranges
                 pure $ Just matchingRanges
 
           let
@@ -173,11 +173,22 @@ findMatchingWeapons filter dbState = do
           FromOb6 -> Just allPotencies.ob6
           FromOb10 -> Just allPotencies.ob10
 
-  matchRanges :: FilterRange -> Array GroupedWeaponRange -> Maybe (NonEmptyArray GroupedWeaponRange)
-  matchRanges filterRange ranges =
+  matchRanges :: Maybe ObRange -> FilterRange -> Array GroupedWeaponRange -> Maybe (NonEmptyArray GroupedWeaponRange)
+  matchRanges ownedOb filterRange ranges =
     ranges
-      # Arr.filter (\r -> matchRange filterRange r.range)
+      # Arr.filter (\r -> matchRange filterRange (rangeForOb ownedOb r.allRanges))
       # NAR.fromArray
+
+  -- An effect's range can vary by overboost level, so we match against the range
+  -- at the user's owned OB. For an unowned weapon (no selected OB), we match on its
+  -- OB0 range, preserving the previous behavior.
+  rangeForOb :: Maybe ObRange -> AllRanges -> Range
+  rangeForOb = case _ of
+    Just (ObRange { from: FromOb0 }) -> _.ob0
+    Just (ObRange { from: FromOb1 }) -> _.ob1
+    Just (ObRange { from: FromOb6 }) -> _.ob6
+    Just (ObRange { from: FromOb10 }) -> _.ob10
+    Nothing -> _.ob0
 
   matchRange :: FilterRange -> Range -> Boolean
   matchRange =

--- a/src/Core/Weapons/Search.purs
+++ b/src/Core/Weapons/Search.purs
@@ -179,9 +179,11 @@ findMatchingWeapons filter dbState = do
       # Arr.filter (\r -> matchRange filterRange (rangeForOb ownedOb r.allRanges))
       # NAR.fromArray
 
-  -- An effect's range can vary by overboost level, so we match against the range
-  -- at the user's owned OB. For an unowned weapon (no selected OB), we match on its
-  -- OB0 range, preserving the previous behavior.
+  -- An effect's range can vary by overboost level,
+  -- e.g. Festive Sword's Enliven is `Self` at OB0/OB1 and `All` at OB6/OB10.
+  -- So we match against the range at the user's owned OB.
+  -- For an unowned weapon (no selected OB), we match on its
+  -- OB0 range.
   rangeForOb :: Maybe ObRange -> AllRanges -> Range
   rangeForOb = case _ of
     Just (ObRange { from: FromOb0 }) -> _.ob0

--- a/test/Test/Core/Weapons/SearchSpec.purs
+++ b/test/Test/Core/Weapons/SearchSpec.purs
@@ -12,7 +12,7 @@ import Core.Weapons.Search as Search
 import Data.Array as Arr
 import Data.Array.NonEmpty as NAR
 import Data.Map as Map
-import Data.Maybe (Maybe(..), maybe)
+import Data.Maybe (Maybe(..), isJust, maybe)
 import Data.Newtype (unwrap)
 import Data.Set as Set
 import Data.String.NonEmpty (NonEmptyString)
@@ -30,6 +30,7 @@ spec =
     assignWeaponSpec
     searchExamplesSpec
     findMatchingWeaponsSpec
+    enlivenObRangeSpec
 
 combinationsSpec :: Spec Unit
 combinationsSpec = do
@@ -425,6 +426,49 @@ findMatchingWeaponsSpec = do
         dbState.userState.weapons
 
     pure $ dbState { userState { weapons = weapons } }
+
+-- Regression test for effects whose range varies by overboost level.
+-- Festive Sword's Enliven is `Self` at OB0/OB1 but `All` at OB6/OB10,
+-- so whether it matches a range filter depends on the owned OB level.
+enlivenObRangeSpec :: Spec Unit
+enlivenObRangeSpec = do
+  describe "effect range that varies by overboost level" do
+    it "filters Enliven by the range at the owned OB level" do
+      dbState <- T.loadTestDbState
+
+      let
+        festiveSword = WeaponName (nes @"Festive Sword")
+        ob0to5 = ObRange { from: FromOb0, to: ToOb5 }
+        ob6to10 = ObRange { from: FromOb6, to: ToOb10 }
+        enlivenAll = { effectType: FilterEnliven, range: FilterAll, minBasePotency: Low, minMaxPotency: Low }
+        enlivenSelf = { effectType: FilterEnliven, range: FilterSelfOrSingleTargetOrAll, minBasePotency: Low, minMaxPotency: Low }
+
+        matches :: ObRange -> Filter -> Maybe FilterResultWeapon
+        matches obRange filter =
+          dbState
+            # setOwned festiveSword obRange
+            # Search.findMatchingWeapons filter
+            # _.matchingWeapons
+            # findByName festiveSword
+
+      -- Enliven is `All` at OB6/OB10: owned at OB6-10, it matches a "range: All" filter.
+      (matches ob6to10 enlivenAll <#> _.matchesFilters) `shouldEqual` Just true
+
+      -- Enliven is `Self` at OB0/OB1: owned at OB0-5, it must NOT match a "range: All" filter...
+      (isJust $ matches ob0to5 enlivenAll) `shouldEqual` false
+
+      -- ...but it must match a "Self / Single Target / All" filter.
+      (matches ob0to5 enlivenSelf <#> _.matchesFilters) `shouldEqual` Just true
+  where
+  findByName :: WeaponName -> Array FilterResultWeapon -> Maybe FilterResultWeapon
+  findByName name = Arr.find (\w -> w.weapon.weapon.name == name)
+
+  setOwned :: WeaponName -> ObRange -> DbState -> DbState
+  setOwned name obRange dbState =
+    dbState
+      { userState
+          { weapons = Map.update (\w -> Just $ w { ownedOb = Just obRange }) name dbState.userState.weapons }
+      }
 
 mkWeapon :: NonEmptyString -> CharacterName -> WeaponData
 mkWeapon id character =


### PR DESCRIPTION
Fixes #20 

The function `groupForWeaponEffect` has this invariant:
```
  -- INVARIANT: this function assumes an effect has the same range at all overboost levels,
  -- so it just returns the range for the effect at OB0.
```

There are 2 new weapons that break this invariant, for the effect `Enliven`.
`Festive Sword` and `Noble Parasol` have Enliven with range "Self" at OB0 and OB1, and the range becomes "All Allies" at OB6 and OB10.

This PR removes that invariant.

